### PR TITLE
module/Makefile: fix parallel builds and adds workaround for codegen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 *.gen.h
 *.gen.c
 *.cmd
+*~
+ruby_codegen

--- a/src/module/Makefile
+++ b/src/module/Makefile
@@ -6,12 +6,13 @@ KRF_SYSCALL_SRCS_FAKE := $(notdir $(wildcard $M/syscalls/*.c))
 KRF_SYSCALL_OBJS_FAKE := $(KRF_SYSCALL_SRCS_FAKE:.c=.o)
 KRF_SYSCALL_OBJS = $(foreach obj,$(KRF_SYSCALL_OBJS_FAKE),syscalls/$(obj))
 KRF_SYSCALL_YMLS := $(wildcard codegen/syscalls/*.yml)
+KRF_HEADER_FILES := $(notdir $(wildcard $M/*.h))
 ccflags-y := -DKRF_CODEGEN=1
 
 obj-m += $(MOD).o
 $(MOD)-objs := krf.o config.o syscalls.o $(KRF_SYSCALL_OBJS)
 
-all: ruby_codegen
+all: ruby_codegen $(KRF_HEADER_FILES)
 	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules
 
 # .PHONY: codegen # Cannot be phony because phony are always run

--- a/src/module/Makefile
+++ b/src/module/Makefile
@@ -5,23 +5,24 @@ MOD := krfx
 KRF_SYSCALL_SRCS_FAKE := $(notdir $(wildcard $M/syscalls/*.c))
 KRF_SYSCALL_OBJS_FAKE := $(KRF_SYSCALL_SRCS_FAKE:.c=.o)
 KRF_SYSCALL_OBJS = $(foreach obj,$(KRF_SYSCALL_OBJS_FAKE),syscalls/$(obj))
-
+KRF_SYSCALL_YMLS := $(wildcard codegen/syscalls/*.yml)
 ccflags-y := -DKRF_CODEGEN=1
 
 obj-m += $(MOD).o
 $(MOD)-objs := krf.o config.o syscalls.o $(KRF_SYSCALL_OBJS)
 
-all: codegen
-	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules
+all: ruby_codegen
+	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules
 
-.PHONY: codegen
-codegen:
+# .PHONY: codegen # Cannot be phony because phony are always run
+ruby_codegen: $(KRF_SYSCALL_YMLS) codegen/codegen
 	ruby codegen/codegen
+	@touch ruby_codegen # Stops it from always being run
 
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) clean
+	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) clean
 	rm -f *.ur-safe # some garbage not cleaned by the kernel's clean target
-	rm -f *.gen.x *.gen.h */*.gen.h */*.gen.c # codegen files
+	rm -f *.gen.x *.gen.h */*.gen.h */*.gen.c ruby_codegen # codegen files
 
 insmod: krfx.ko
 	sudo insmod $(MOD).ko


### PR DESCRIPTION
Turns the codegen makefile rule into an empty rule (<https://www.gnu.org/software/make/manual/html_node/Empty-Targets.html>) in order to save the files as dependencies.
Fixes #11 