### PR TITLE
 krfctl: Split freebsd and linux and implement freebsd

### DIFF
--- a/src/krfctl/Makefile
+++ b/src/krfctl/Makefile
@@ -1,5 +1,6 @@
 PROG := krfctl
-OBJS := $(PROG).o table.gen.o profiles.gen.o
+SRCS := $(PROG).c table.gen.c profiles.gen.c $(wildcard ./$(PLATFORM)/*.c)
+OBJS := $(SRCS:.c=.o)
 
 all: gentable $(PROG)
 
@@ -13,6 +14,8 @@ genprofiles:
 
 table.gen.c: gentable
 profiles.gen.c: genprofiles
+
+$(OBJS): $(SRCS)
 
 $(PROG): $(OBJS)
 

--- a/src/krfctl/freebsd/freebsd.c
+++ b/src/krfctl/freebsd/freebsd.c
@@ -15,7 +15,7 @@
 
 /* control will interpret any number larger than its syscall table
  * as a command to clear all current masks.
- * it's a good bet that linux will never have 65535 syscalls.
+ * it's a good bet that FreeBSD will never have 65535 syscalls.
  */
 #define CLEAR_MAGIC 65535
 
@@ -38,7 +38,11 @@ void fault_syscall(const char *sys_name) {
   }
 
   if (sysctlbyname(CONTROL_NAME, NULL, NULL, &syscall, sizeof(syscall)) < 0) {
-    errx(errno, "faulting for %s unimplemented", sys_name);
+    if (errno == EOPNOTSUPP) {
+      errx(errno, "faulting for %s unimplemented", sys_name);
+    } else {
+      err(errno, "sysctl " CONTROL_NAME);
+    }
   }
 }
 

--- a/src/krfctl/freebsd/freebsd.c
+++ b/src/krfctl/freebsd/freebsd.c
@@ -1,0 +1,103 @@
+#include <stdio.h>
+#include <string.h>
+#include <sys/errno.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <err.h>
+#include <string.h>
+#include <sys/sysctl.h>
+
+#include "../krfctl.h"
+
+/* control will interpret any number larger than its syscall table
+ * as a command to clear all current masks.
+ * it's a good bet that linux will never have 65535 syscalls.
+ */
+#define CLEAR_MAGIC 65535
+
+#define CONTROL_NAME "krf.control"
+#define RNG_STATE_NAME "krf.rng_state"
+#define PROBABILITY_NAME "krf.probability"
+#define LOG_FAULTS_NAME "krf.log_faults"
+#define TARGETING_NAME "krf.targeting"
+
+void fault_syscall(const char *sys_name) {
+  const char *sys_num;
+  unsigned int syscall;
+  
+  if (!(sys_num = lookup_syscall_number(sys_name))) {
+    errx(1, "couldn't find syscall %s", sys_name);
+  }
+
+  if (sscanf(sys_num, "%u", &syscall) != 1) {
+    err(errno, "weird syscall number");
+  }
+
+  if (sysctlbyname(CONTROL_NAME, NULL, NULL, &syscall, sizeof(syscall)) < 0) {
+    errx(errno, "faulting for %s unimplemented", sys_name);
+  }
+}
+
+void clear_faulty_calls(void) {
+  unsigned int clr = CLEAR_MAGIC;
+  if (sysctlbyname(CONTROL_NAME, NULL, NULL, &clr, sizeof(clr)) < 0) {
+    err(errno, "write " CONTROL_NAME);
+  }
+}
+
+void set_rng_state(const char *state) {
+  unsigned int rng_state;
+
+  if (sscanf(state, "%u", &rng_state) != 1) {
+    err(1, "Weird rng_state");
+  }
+  
+  if (sysctlbyname(RNG_STATE_NAME, NULL, NULL, &rng_state, sizeof(rng_state)) < 0) {
+    err(errno, "write " RNG_STATE_NAME);
+  }
+}
+
+void set_prob_state(const char *state) {
+  unsigned int prob_state;
+
+  if (sscanf(state, "%u", &prob_state) != 1) {
+    err(1, "Weird prob_state");
+  }
+
+  if (sysctlbyname(PROBABILITY_NAME, NULL, NULL, &prob_state, sizeof(prob_state)) < 0) {
+    err(errno, "write " PROBABILITY_NAME);
+  }
+}
+
+void toggle_fault_logging(void) {
+  unsigned int state;
+  size_t amt_read = sizeof(state);
+  if (sysctlbyname(LOG_FAULTS_NAME, &state, &amt_read, NULL, 0) < 0) {
+    err(errno, "read " LOG_FAULTS_NAME);
+  }
+
+  state = !state;
+
+  if (sysctlbyname(LOG_FAULTS_NAME, NULL, NULL, &state, sizeof(state)) < 0) {
+    err(errno, "write " LOG_FAULTS_NAME);
+  }
+}
+
+void set_targeting(unsigned int mode, const char *data) {
+  char buf[32] = {0};
+  if (snprintf(buf, sizeof(buf), "%u %s", mode, data) < 0) {
+    err(errno, "snprintf");
+  }
+
+  if (sysctlbyname(TARGETING_NAME, NULL, NULL, &buf, strlen(buf)) < 0) {
+    errx(errno, "write " TARGETING_NAME " - %s", buf);
+  }
+}
+							
+  
+  
+		    

--- a/src/krfctl/freebsd/freebsd.c
+++ b/src/krfctl/freebsd/freebsd.c
@@ -28,7 +28,7 @@
 void fault_syscall(const char *sys_name) {
   const char *sys_num;
   unsigned int syscall;
-  
+
   if (!(sys_num = lookup_syscall_number(sys_name))) {
     errx(1, "couldn't find syscall %s", sys_name);
   }
@@ -55,7 +55,7 @@ void set_rng_state(const char *state) {
   if (sscanf(state, "%u", &rng_state) != 1) {
     err(1, "Weird rng_state");
   }
-  
+
   if (sysctlbyname(RNG_STATE_NAME, NULL, NULL, &rng_state, sizeof(rng_state)) < 0) {
     err(errno, "write " RNG_STATE_NAME);
   }
@@ -97,7 +97,3 @@ void set_targeting(unsigned int mode, const char *data) {
     errx(errno, "write " TARGETING_NAME " - %s", buf);
   }
 }
-							
-  
-  
-		    

--- a/src/krfctl/krfctl.c
+++ b/src/krfctl/krfctl.c
@@ -12,19 +12,7 @@
 
 #include "krfctl.h"
 
-#define CONTROL_FILE "/proc/krf/control"
-#define RNG_STATE_FILE "/proc/krf/rng_state"
-#define PROBABILITY_FILE "/proc/krf/probability"
-#define LOG_FAULTS_FILE "/proc/krf/log_faults"
-#define TARGETING_FILE "/proc/krf/targeting"
-
-/* control will interpret any number larger than its syscall table
- * as a command to clear all current masks.
- * it's a good bet that linux will never have 65535 syscalls.
- */
-#define CLEAR_MAGIC "65535"
-
-static const char *lookup_syscall_number(const char *sys_name) {
+const char *lookup_syscall_number(const char *sys_name) {
   for (syscall_lookup_t *elem = syscall_lookup_table; elem->sys_name != NULL; elem++) {
     if (!strcmp(sys_name, elem->sys_name)) {
       return elem->sys_num;
@@ -42,34 +30,6 @@ static const char **lookup_syscall_profile(const char *profile) {
   }
 
   return NULL;
-}
-
-static void fault_syscall(const char *sys_name) {
-  int fd;
-  const char *sys_num;
-
-  /* TODO(ww): Opening the control file once per syscall is
-   * pretty nasty, but I don't like passing a fd around.
-   * Maybe a static variable that we test-and-set?
-   */
-  if ((fd = open(CONTROL_FILE, O_WRONLY)) < 0) {
-    err(errno, "open " CONTROL_FILE);
-  }
-
-  if (!(sys_num = lookup_syscall_number(sys_name))) {
-    errx(1, "couldn't find syscall: %s", sys_name);
-  }
-
-  if (write(fd, sys_num, strlen(sys_num)) < 0) {
-    /* friendly error message on unsupported syscall */
-    if (errno == EOPNOTSUPP) {
-      errx(errno, "faulting for %s unimplemented", sys_name);
-    } else {
-      err(errno, "write " CONTROL_FILE);
-    }
-  }
-
-  close(fd);
 }
 
 static void fault_syscall_spec(const char *s) {
@@ -97,94 +57,6 @@ static void fault_syscall_profile(const char *profile) {
   for (i = 0; syscalls[i]; i++) {
     fault_syscall(syscalls[i]);
   }
-}
-
-static void clear_faulty_calls(void) {
-  int fd;
-
-  if ((fd = open(CONTROL_FILE, O_WRONLY)) < 0) {
-    err(errno, "open " CONTROL_FILE);
-  }
-
-  if (write(fd, CLEAR_MAGIC, strlen(CLEAR_MAGIC)) < 0) {
-    err(errno, "write " CONTROL_FILE);
-  }
-
-  close(fd);
-}
-
-static void set_rng_state(const char *state) {
-  int fd;
-
-  if ((fd = open(RNG_STATE_FILE, O_WRONLY)) < 0) {
-    err(errno, "open " RNG_STATE_FILE);
-  }
-
-  if (write(fd, state, strlen(state)) < 0) {
-    err(errno, "write " CONTROL_FILE);
-  }
-
-  close(fd);
-}
-
-static void set_prob_state(const char *state) {
-  int fd;
-
-  if ((fd = open(PROBABILITY_FILE, O_WRONLY)) < 0) {
-    err(errno, "open " PROBABILITY_FILE);
-  }
-
-  if (write(fd, state, strlen(state)) < 0) {
-    err(errno, "write " CONTROL_FILE);
-  }
-
-  close(fd);
-}
-
-static void toggle_fault_logging(void) {
-  int fd;
-  char buf[32] = {0};
-  unsigned int state;
-
-  if ((fd = open(LOG_FAULTS_FILE, O_RDWR)) < 0) {
-    err(errno, "open " LOG_FAULTS_FILE);
-  }
-
-  if (read(fd, buf, sizeof(buf) - 1) < 0) {
-    err(errno, "read " LOG_FAULTS_FILE);
-  }
-
-  if (sscanf(buf, "%u", &state) != 1) {
-    errx(1, "weird logging state: %s", buf);
-  }
-
-  state = !state;
-  memset(buf, 0, sizeof(buf));
-  snprintf(buf, sizeof(buf), "%u", state);
-
-  if (write(fd, buf, strlen(buf)) < 0) {
-    err(errno, "write " LOG_FAULTS_FILE);
-  }
-
-  close(fd);
-}
-
-static void set_targeting(unsigned int mode, const char *data) {
-  int fd;
-  char buf[32] = {0};
-  if ((fd = open(TARGETING_FILE, O_WRONLY)) < 0) {
-    err(errno, "open " TARGETING_FILE);
-  }
-
-  if (snprintf(buf, sizeof(buf), "%u %s", mode, data) < 0) {
-    err(errno, "snprintf");
-  }
-
-  if (write(fd, buf, strlen(buf)) < 0) {
-    err(errno, "write " TARGETING_FILE);
-  }
-
-  close(fd);
 }
 
 enum { TARGET_PERSONALITY = 0, TARGET_PID, TARGET_UID, TARGET_GID, TARGET_NUM_MODES };

--- a/src/krfctl/krfctl.h
+++ b/src/krfctl/krfctl.h
@@ -17,3 +17,11 @@ typedef struct fault_profile_t {
 
 extern syscall_lookup_t syscall_lookup_table[];
 extern fault_profile_t fault_profile_table[];
+
+const char *lookup_syscall_number(const char *sys_name);
+void fault_syscall(const char *sys_name);
+void clear_faulty_calls(void);
+void set_rng_state(const char *state);
+void set_prob_state(const char *state);
+void toggle_fault_logging(void);
+void set_targeting(unsigned int mode, const char *data);

--- a/src/krfctl/linux/linux.c
+++ b/src/krfctl/linux/linux.c
@@ -1,0 +1,141 @@
+#include <stdio.h>
+#include <string.h>
+#include <sys/errno.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <err.h>
+#include <string.h>
+
+#include "../krfctl.h"
+
+/* control will interpret any number larger than its syscall table
+ * as a command to clear all current masks.
+ * it's a good bet that linux will never have 65535 syscalls.
+ */
+#define CLEAR_MAGIC "65535"
+
+#define CONTROL_FILE "/proc/krf/control"
+#define RNG_STATE_FILE "/proc/krf/rng_state"
+#define PROBABILITY_FILE "/proc/krf/probability"
+#define LOG_FAULTS_FILE "/proc/krf/log_faults"
+#define TARGETING_FILE "/proc/krf/targeting"
+
+void fault_syscall(const char *sys_name) {
+  int fd;
+  const char *sys_num;
+
+  /* TODO(ww): Opening the control file once per syscall is
+   * pretty nasty, but I don't like passing a fd around.
+   * Maybe a static variable that we test-and-set?
+   */
+  if ((fd = open(CONTROL_FILE, O_WRONLY)) < 0) {
+    err(errno, "open " CONTROL_FILE);
+  }
+
+  if (!(sys_num = lookup_syscall_number(sys_name))) {
+    errx(1, "couldn't find syscall: %s", sys_name);
+  }
+
+  if (write(fd, sys_num, strlen(sys_num)) < 0) {
+    /* friendly error message on unsupported syscall */
+    if (errno == EOPNOTSUPP) {
+      errx(errno, "faulting for %s unimplemented", sys_name);
+    } else {
+      err(errno, "write " CONTROL_FILE);
+    }
+  }
+
+  close(fd);
+}
+
+void clear_faulty_calls(void) {
+  int fd;
+
+  if ((fd = open(CONTROL_FILE, O_WRONLY)) < 0) {
+    err(errno, "open " CONTROL_FILE);
+  }
+
+  if (write(fd, CLEAR_MAGIC, strlen(CLEAR_MAGIC)) < 0) {
+    err(errno, "write " CONTROL_FILE);
+  }
+
+  close(fd);
+}
+
+void set_rng_state(const char *state) {
+  int fd;
+
+  if ((fd = open(RNG_STATE_FILE, O_WRONLY)) < 0) {
+    err(errno, "open " RNG_STATE_FILE);
+  }
+
+  if (write(fd, state, strlen(state)) < 0) {
+    err(errno, "write " CONTROL_FILE);
+  }
+
+  close(fd);
+}
+
+void set_prob_state(const char *state) {
+  int fd;
+
+  if ((fd = open(PROBABILITY_FILE, O_WRONLY)) < 0) {
+    err(errno, "open " PROBABILITY_FILE);
+  }
+
+  if (write(fd, state, strlen(state)) < 0) {
+    err(errno, "write " CONTROL_FILE);
+  }
+
+  close(fd);
+}
+
+void toggle_fault_logging(void) {
+  int fd;
+  char buf[32] = {0};
+  unsigned int state;
+
+  if ((fd = open(LOG_FAULTS_FILE, O_RDWR)) < 0) {
+    err(errno, "open " LOG_FAULTS_FILE);
+  }
+
+  if (read(fd, buf, sizeof(buf) - 1) < 0) {
+    err(errno, "read " LOG_FAULTS_FILE);
+  }
+
+  if (sscanf(buf, "%u", &state) != 1) {
+    errx(1, "weird logging state: %s", buf);
+  }
+
+  state = !state;
+  memset(buf, 0, sizeof(buf));
+  snprintf(buf, sizeof(buf), "%u", state);
+
+  if (write(fd, buf, strlen(buf)) < 0) {
+    err(errno, "write " LOG_FAULTS_FILE);
+  }
+
+  close(fd);
+}
+
+void set_targeting(unsigned int mode, const char *data) {
+  int fd;
+  char buf[32] = {0};
+  if ((fd = open(TARGETING_FILE, O_WRONLY)) < 0) {
+    err(errno, "open " TARGETING_FILE);
+  }
+
+  if (snprintf(buf, sizeof(buf), "%u %s", mode, data) < 0) {
+    err(errno, "snprintf");
+  }
+
+  if (write(fd, buf, strlen(buf)) < 0) {
+    err(errno, "write " TARGETING_FILE);
+  }
+
+  close(fd);
+}


### PR DESCRIPTION
Closes #30 

Exact same interface for the user, but all calls that write to procfs instead do `sysctl` work.