### PR TITLE
krfexec: Add freebsd krfexec functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ sudo ./src/krfctl/krfctl -C
 ./src/krfexec/krfexec firefox
 ```
 
+On FreeBSD, `krfexec` requires root privileges. By default, it will attempt to use `SUDO_UID`
+and the username returned by `getlogin_r` to return to a non-root user before executing the target.
+To force a particular UID, export `REAL_UID`, e.g.:
+
+```bash
+REAL_UID=1000 sudo ./src/krfexec/krfexec ls
+```
+
 ## Configuration
 
 **NOTE**: Most users should use `krfctl` instead of manipulating these files by hand.

--- a/src/krfexec/freebsd/freebsd.c
+++ b/src/krfexec/freebsd/freebsd.c
@@ -20,7 +20,7 @@
 static uid_t guess_original_uid(void) {
   uid_t uid;
 
-  uid_s = getenv("REAL_UID");
+  const char *uid_s = getenv("REAL_UID");
   if (uid_s != NULL) {
     if (sscanf(uid_s, "%u", &uid) != 1) {
       errx(1, "weird REAL_UID value: %s", uid_s);
@@ -28,7 +28,7 @@ static uid_t guess_original_uid(void) {
     return uid;
   }
 
-  const char *uid_s = getenv("SUDO_UID");
+  uid_s = getenv("SUDO_UID");
   if (uid_s != NULL) {
     if (sscanf(uid_s, "%u", &uid) != 1) {
       errx(1, "weird SUDO_UID value: %s", uid_s);

--- a/src/krfexec/freebsd/freebsd.c
+++ b/src/krfexec/freebsd/freebsd.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/sysctl.h>
@@ -5,26 +6,66 @@
 #include <errno.h>
 #include <err.h>
 #include <string.h>
+#include <pwd.h>
 
 #include "../krfexec.h"
 
+/* This employs a collection of hacks to attempt to drop down
+ * to the "originating" user, including:
+ *
+ * 1. Checking for SUDO_UID, and using its value
+ * 2. Checking for REAL_UID, which we document
+ * 3. Checking getlogin_r, which returns the username for the controlling terminal
+ */
+static uid_t guess_original_uid(void) {
+  uid_t uid;
+
+  const char *uid_s = getenv("SUDO_UID");
+  if (uid_s != NULL) {
+    if (sscanf(uid_s, "%u", &uid) != 1) {
+      errx(1, "weird SUDO_UID value: %s", uid_s);
+    }
+    return uid;
+  }
+
+  uid_s = getenv("REAL_UID");
+  if (uid_s != NULL) {
+    if (sscanf(uid_s, "%u", &uid) != 1) {
+      errx(1, "weird REAL_UID value: %s", uid_s);
+    }
+    return uid;
+  }
+
+  char login[L_cuserid] = {0};
+  if (getlogin_r(login, L_cuserid) == 0) {
+    const struct passwd *pwd = getpwnam(login);
+    if (pwd != NULL) {
+      return pwd->pw_uid;
+    }
+  }
+
+  errx(1, "barf: all guessing methods failed, set REAL_UID manually");
+}
+
 void krfexec_prep(void) {
+  if (getuid() != 0) {
+    errx(1, "krfexec should be run as root on freebsd");
+  }
+
   char buf[32] = {0};
-  pid_t pid;
-
-  pid = getpid();
-
+  pid_t pid = getpid();
   if (snprintf(buf, 32, "1 %u", (unsigned int)pid) < 0) {
-    err(errno, "snprintf");
+    errx(1, "snprintf");
   }
 
   if (sysctlbyname(KRF_TARGETING_NAME, NULL, NULL, &buf, strnlen(buf, 32)) < 0) {
     err(errno, "sysctl failed");
   }
 
-  /* TODO(hw)
-   * This must be run as root to successfully do sysctl, so setting euid and egid
-   * back to the real uid and real gid will allow programs to be executed without
-   * potentially dangerous root privileges.
-   */
+  uid_t uid = guess_original_uid();
+  if (uid != getuid()) {
+    if (setuid(uid) < 0) {
+      err(errno, "setuid %u", uid);
+    }
+  }
 }

--- a/src/krfexec/freebsd/freebsd.c
+++ b/src/krfexec/freebsd/freebsd.c
@@ -21,4 +21,10 @@ void krfexec_prep(void) {
   if (sysctlbyname(KRF_TARGETING_NAME, NULL, NULL, &buf, strnlen(buf, 32)) < 0) {
     err(errno, "sysctl failed");
   }
+  
+  /* TODO(hw)
+   * This must be run as root to successfully do sysctl, so setting euid and egid
+   * back to the real uid and real gid will allow programs to be executed without
+   * potentially dangerous root privileges.
+   */
 }

--- a/src/krfexec/freebsd/freebsd.c
+++ b/src/krfexec/freebsd/freebsd.c
@@ -13,25 +13,25 @@
 /* This employs a collection of hacks to attempt to drop down
  * to the "originating" user, including:
  *
- * 1. Checking for SUDO_UID, and using its value
- * 2. Checking for REAL_UID, which we document
+ * 1. Checking for REAL_UID, which we document
+ * 2. Checking for SUDO_UID, and using its value
  * 3. Checking getlogin_r, which returns the username for the controlling terminal
  */
 static uid_t guess_original_uid(void) {
   uid_t uid;
 
-  const char *uid_s = getenv("SUDO_UID");
-  if (uid_s != NULL) {
-    if (sscanf(uid_s, "%u", &uid) != 1) {
-      errx(1, "weird SUDO_UID value: %s", uid_s);
-    }
-    return uid;
-  }
-
   uid_s = getenv("REAL_UID");
   if (uid_s != NULL) {
     if (sscanf(uid_s, "%u", &uid) != 1) {
       errx(1, "weird REAL_UID value: %s", uid_s);
+    }
+    return uid;
+  }
+
+  const char *uid_s = getenv("SUDO_UID");
+  if (uid_s != NULL) {
+    if (sscanf(uid_s, "%u", &uid) != 1) {
+      errx(1, "weird SUDO_UID value: %s", uid_s);
     }
     return uid;
   }

--- a/src/krfexec/freebsd/freebsd.c
+++ b/src/krfexec/freebsd/freebsd.c
@@ -21,7 +21,7 @@ void krfexec_prep(void) {
   if (sysctlbyname(KRF_TARGETING_NAME, NULL, NULL, &buf, strnlen(buf, 32)) < 0) {
     err(errno, "sysctl failed");
   }
-  
+
   /* TODO(hw)
    * This must be run as root to successfully do sysctl, so setting euid and egid
    * back to the real uid and real gid will allow programs to be executed without

--- a/src/krfexec/freebsd/freebsd.c
+++ b/src/krfexec/freebsd/freebsd.c
@@ -1,6 +1,24 @@
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <stdio.h>
+#include <errno.h>
+#include <err.h>
+#include <string.h>
+
 #include "../krfexec.h"
 
 void krfexec_prep(void) {
-  /* Nothing for now. */
-  return;
+  char buf[32] = {0};
+  pid_t pid;
+
+  pid = getpid();
+
+  if (snprintf(buf, 32, "1 %u", (unsigned int)pid) < 0) {
+    err(errno, "snprintf");
+  }
+
+  if (sysctlbyname(KRF_TARGETING_NAME, NULL, NULL, &buf, strnlen(buf, 32)) < 0) {
+    err(errno, "sysctl failed");
+  }
 }

--- a/src/krfexec/krfexec.c
+++ b/src/krfexec/krfexec.c
@@ -5,6 +5,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/fcntl.h>
+#include <errno.h>
+#include <err.h>
 
 #include "krfexec.h"
 

--- a/src/krfexec/krfexec.h
+++ b/src/krfexec/krfexec.h
@@ -6,5 +6,6 @@
 /* TODO(ww): Put this in a common include directory.
  */
 #define KRF_PERSONALITY 28
+#define KRF_TARGETING_NAME "krf.targeting"
 
 void krfexec_prep(void);


### PR DESCRIPTION
Closes #31  


Must be run as root due to the use of `sysctl`. This has the unfortunate side affect of running the executed command with root privileges as well.