### PR TITLE
codegen/freebsd: Add FreeBSD syscalls

### DIFF
--- a/src/module/codegen/freebsd/__getcwd.yml
+++ b/src/module/codegen/freebsd/__getcwd.yml
@@ -1,0 +1,6 @@
+proto: struct thread *td, struct __getcwd_args *uap
+parms: td, uap
+errors:
+  - ENODEV
+  - EINVAL
+  - EFAULT

--- a/src/module/codegen/freebsd/__semctl.yml
+++ b/src/module/codegen/freebsd/__semctl.yml
@@ -1,0 +1,5 @@
+proto: struct thread *td, struct __semctl_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EFAULT

--- a/src/module/codegen/freebsd/__setugid.yml
+++ b/src/module/codegen/freebsd/__setugid.yml
@@ -1,0 +1,4 @@
+proto: struct thread *td, struct __setugid_args *uap
+parms: td, uap
+errors:
+  - EINVAL

--- a/src/module/codegen/freebsd/accept4.yml
+++ b/src/module/codegen/freebsd/accept4.yml
@@ -1,4 +1,4 @@
-proto: struct thread *td, struct accept_args *uap
+proto: struct thread *td, struct accept4_args *uap
 parms: td, uap
 errors:
   - EBADF
@@ -11,5 +11,6 @@ errors:
   - EWOULDBLOCK
   - EAGAIN
   - ECONNABORTED
+  - EINVAL
 profiles:
   - net

--- a/src/module/codegen/freebsd/access.yml
+++ b/src/module/codegen/freebsd/access.yml
@@ -1,0 +1,15 @@
+proto: struct thread *td, struct access_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - ELOOP
+  - EROFS
+  - ETXTBSY
+  - EACCES
+  - EFAULT
+  - EIO
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/acct.yml
+++ b/src/module/codegen/freebsd/acct.yml
@@ -1,0 +1,14 @@
+proto: struct thread *td, struct acct_args *uap
+parms: td, uap
+errors:
+  - EPERM
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EROFS
+  - EFAULT
+  - EIO
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/adjtime.yml
+++ b/src/module/codegen/freebsd/adjtime.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct adjtime_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EPERM
+profiles:
+  - time

--- a/src/module/codegen/freebsd/aio_cancel.yml
+++ b/src/module/codegen/freebsd/aio_cancel.yml
@@ -1,0 +1,6 @@
+proto: struct thread *td, struct aio_cancel_args *uap
+parms: td, uap
+errors:
+  - EBADF
+profiles:
+  - io

--- a/src/module/codegen/freebsd/aio_error.yml
+++ b/src/module/codegen/freebsd/aio_error.yml
@@ -1,0 +1,6 @@
+proto: struct thread *td, struct aio_error_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+profiles:
+  - io

--- a/src/module/codegen/freebsd/aio_fsync.yml
+++ b/src/module/codegen/freebsd/aio_fsync.yml
@@ -1,0 +1,10 @@
+proto: struct thread *td, struct aio_fsync_args *uap
+parms: td, uap
+errors:
+  - EAGAIN
+  - EINVAL
+  - EOPNOTSUPP
+  - EINVAL
+  - EBADF
+profiles:
+  - io

--- a/src/module/codegen/freebsd/aio_mlock.yml
+++ b/src/module/codegen/freebsd/aio_mlock.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct aio_mlock_args *uap
+parms: td, uap
+errors:
+  - EAGAIN
+  - EINVAL
+profiles:
+  - io

--- a/src/module/codegen/freebsd/aio_read.yml
+++ b/src/module/codegen/freebsd/aio_read.yml
@@ -1,0 +1,11 @@
+proto: struct thread *td, struct aio_read_args *uap
+parms: td, uap
+errors:
+  - EAGAIN
+  - EINVAL
+  - EOPNOTSUPP
+  - EBADF
+  - EOVERFLOW
+  - ECANCELED
+profiles:
+  - io

--- a/src/module/codegen/freebsd/aio_return.yml
+++ b/src/module/codegen/freebsd/aio_return.yml
@@ -1,0 +1,6 @@
+proto: struct thread *td, struct aio_return_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+profiles:
+  - io

--- a/src/module/codegen/freebsd/aio_suspend.yml
+++ b/src/module/codegen/freebsd/aio_suspend.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct aio_suspend_args *uap
+parms: td, uap
+errors:
+  - EAGAIN
+  - EINVAL
+  - EINTR
+profiles:
+  - io

--- a/src/module/codegen/freebsd/aio_waitcomplete.yml
+++ b/src/module/codegen/freebsd/aio_waitcomplete.yml
@@ -1,0 +1,10 @@
+proto: struct thread *td, struct aio_waitcomplete_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EAGAIN
+  - EINTR
+  - EWOULDBLOCK
+  - EINPROGRESS
+profiles:
+  - io

--- a/src/module/codegen/freebsd/aio_write.yml
+++ b/src/module/codegen/freebsd/aio_write.yml
@@ -1,0 +1,10 @@
+proto: struct thread *td, struct aio_write_args *uap
+parms: td, uap
+errors:
+  - EAGAIN
+  - EINVAL
+  - EOPNOTSUPP
+  - EBADF
+  - ECANCELED
+profiles:
+  - io

--- a/src/module/codegen/freebsd/audit.yml
+++ b/src/module/codegen/freebsd/audit.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct audit_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EINVAL
+  - EPERM
+profiles:
+  - security

--- a/src/module/codegen/freebsd/auditctl.yml
+++ b/src/module/codegen/freebsd/auditctl.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct auditctl_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EINVAL
+  - EPERM
+profiles:
+  - security

--- a/src/module/codegen/freebsd/auditon.yml
+++ b/src/module/codegen/freebsd/auditon.yml
@@ -1,0 +1,9 @@
+proto: struct thread *td, struct auditon_args *uap
+parms: td, uap
+errors:
+  - ENOSYS
+  - EFAULT
+  - EINVAL
+  - EPERM
+profiles:
+  - security

--- a/src/module/codegen/freebsd/bind.yml
+++ b/src/module/codegen/freebsd/bind.yml
@@ -1,0 +1,21 @@
+proto: struct thread *td, struct bind_args *uap
+parms: td, uap
+errors:
+  - EAGAIN
+  - EBADF
+  - EINVAL
+  - ENOTSOCK
+  - EADDRNOTAVAIL
+  - EADDRINUSE
+  - EAFNOSUPPORT
+  - EACCES
+  - EFAULT
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - ELOOP
+  - EIO
+  - EROFS
+  - EISDIR
+profiles:
+  - net

--- a/src/module/codegen/freebsd/bindat.yml
+++ b/src/module/codegen/freebsd/bindat.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct bindat_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - ENOTDIR
+profiles:
+  - net

--- a/src/module/codegen/freebsd/chdir.yml
+++ b/src/module/codegen/freebsd/chdir.yml
@@ -1,0 +1,12 @@
+proto: struct thread *td, struct chdir_args *uap
+parms: td, uap 
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - ELOOP
+  - EACCES
+  - EFAULT
+  - EIO
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/chflags.yml
+++ b/src/module/codegen/freebsd/chflags.yml
@@ -1,0 +1,15 @@
+proto: struct thread *td, struct chflags_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EPERM
+  - EROFS
+  - EFAULT
+  - EIO
+  - EOPNOTSUPP
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/chflagsat.yml
+++ b/src/module/codegen/freebsd/chflagsat.yml
@@ -1,0 +1,15 @@
+proto: struct thread *td, struct chflagsat_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EPERM
+  - EROFS
+  - EFAULT
+  - EIO
+  - EOPNOTSUPP
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/chmod.yml
+++ b/src/module/codegen/freebsd/chmod.yml
@@ -1,0 +1,15 @@
+proto: struct thread *td, struct chmod_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EPERM
+  - EROFS
+  - EFAULT
+  - EIO
+  - EFTYPE 
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/chown.yml
+++ b/src/module/codegen/freebsd/chown.yml
@@ -1,0 +1,14 @@
+proto: struct thread *td, struct chown_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EPERM
+  - EROFS
+  - EFAULT
+  - EIO
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/chroot.yml
+++ b/src/module/codegen/freebsd/chroot.yml
@@ -1,0 +1,13 @@
+proto: struct thread *td, struct chroot_args *uap
+parms: td, uap 
+errors:
+  - ENOTDIR
+  - EPERM
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EFAULT
+  - EIO
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/clock_getcpuclockid2.yml
+++ b/src/module/codegen/freebsd/clock_getcpuclockid2.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct clock_getcpuclockid2_args *uap
+parms: td, uap
+errors:
+  - EPERM
+  - ESRCH
+profiles:
+  - time

--- a/src/module/codegen/freebsd/clock_getres.yml
+++ b/src/module/codegen/freebsd/clock_getres.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct clock_getres_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EPERM
+profiles:
+  - time

--- a/src/module/codegen/freebsd/clock_gettime.yml
+++ b/src/module/codegen/freebsd/clock_gettime.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct clock_gettime_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EPERM
+profiles:
+  - time

--- a/src/module/codegen/freebsd/clock_nanosleep.yml
+++ b/src/module/codegen/freebsd/clock_nanosleep.yml
@@ -1,0 +1,11 @@
+proto: struct thread *td, struct clock_nanosleep_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EINTR
+  - EINVAL
+  - EINVAL
+  - EINVAL
+  - ENOTSUP
+profiles:
+  - time

--- a/src/module/codegen/freebsd/clock_settime.yml
+++ b/src/module/codegen/freebsd/clock_settime.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct clock_settime_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EPERM
+profiles:
+  - time

--- a/src/module/codegen/freebsd/close.yml
+++ b/src/module/codegen/freebsd/close.yml
@@ -1,0 +1,11 @@
+proto: struct thread *td, struct close_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EINTR
+  - ENOSPC
+  - ECONNRESET
+profiles:
+  - io
+  - net
+  - fs

--- a/src/module/codegen/freebsd/closefrom.yml
+++ b/src/module/codegen/freebsd/closefrom.yml
@@ -1,0 +1,11 @@
+proto: struct thread *td, struct closefrom_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EINTR
+  - ENOSPC
+  - ECONNRESET
+profiles:
+  - io
+  - net
+  - fs

--- a/src/module/codegen/freebsd/connect.yml
+++ b/src/module/codegen/freebsd/connect.yml
@@ -1,0 +1,28 @@
+proto: struct thread *td, struct connect_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EINVAL
+  - ENOTSOCK
+  - EADDRNOTAVAIL
+  - EAFNOSUPPORT
+  - EISCONN
+  - ETIMEDOUT
+  - ECONNREFUSED
+  - ECONNRESET
+  - ENETUNREACH
+  - EHOSTUNREACH
+  - EADDRINUSE
+  - EFAULT
+  - EINPROGRESS
+  - EINTR
+  - EALREADY
+  - EACCES
+  - EAGAIN
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - ELOOP
+  - EPERM
+profiles:
+  - net

--- a/src/module/codegen/freebsd/connectat.yml
+++ b/src/module/codegen/freebsd/connectat.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct connectat_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - ENOTDIR
+profiles:
+  - net

--- a/src/module/codegen/freebsd/cpuset.yml
+++ b/src/module/codegen/freebsd/cpuset.yml
@@ -1,0 +1,11 @@
+proto: struct thread *td, struct cpuset_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EDEADLK
+  - EFAULT
+  - ESRCH
+  - EPERM
+  - ENFILE
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/cpuset_getaffinity.yml
+++ b/src/module/codegen/freebsd/cpuset_getaffinity.yml
@@ -1,0 +1,12 @@
+proto: struct thread *td, struct cpuset_getaffinity_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EDEADLK
+  - EFAULT
+  - ESRCH
+  - ERANGE
+  - EPERM
+  - ECAPMODE
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/cpuset_getdomain.yml
+++ b/src/module/codegen/freebsd/cpuset_getdomain.yml
@@ -1,0 +1,12 @@
+proto: struct thread *td, struct cpuset_getdomain_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EDEADLK
+  - EFAULT
+  - ESRCH
+  - ERANGE
+  - EPERM
+  - ECAPMODE
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/cpuset_getid.yml
+++ b/src/module/codegen/freebsd/cpuset_getid.yml
@@ -1,0 +1,11 @@
+proto: struct thread *td, struct cpuset_getid_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EDEADLK
+  - EFAULT
+  - ESRCH
+  - EPERM
+  - ENFILE
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/cpuset_setaffinity.yml
+++ b/src/module/codegen/freebsd/cpuset_setaffinity.yml
@@ -1,0 +1,12 @@
+proto: struct thread *td, struct cpuset_setaffinity_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EDEADLK
+  - EFAULT
+  - ESRCH
+  - ERANGE
+  - EPERM
+  - ECAPMODE
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/cpuset_setdomain.yml
+++ b/src/module/codegen/freebsd/cpuset_setdomain.yml
@@ -1,0 +1,12 @@
+proto: struct thread *td, struct cpuset_setdomain_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EDEADLK
+  - EFAULT
+  - ESRCH
+  - ERANGE
+  - EPERM
+  - ECAPMODE
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/cpuset_setid.yml
+++ b/src/module/codegen/freebsd/cpuset_setid.yml
@@ -1,0 +1,11 @@
+proto: struct thread *td, struct cpuset_setid_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EDEADLK
+  - EFAULT
+  - ESRCH
+  - EPERM
+  - ENFILE
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/dup.yml
+++ b/src/module/codegen/freebsd/dup.yml
@@ -1,0 +1,5 @@
+proto: struct thread *td, struct dup_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EMFILE

--- a/src/module/codegen/freebsd/dup2.yml
+++ b/src/module/codegen/freebsd/dup2.yml
@@ -1,0 +1,4 @@
+proto: struct thread *td, struct dup2_args *uap
+parms: td, uap
+errors:
+  - EBADF

--- a/src/module/codegen/freebsd/eaccess.yml
+++ b/src/module/codegen/freebsd/eaccess.yml
@@ -1,0 +1,15 @@
+proto: struct thread *td, struct eaccess_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - ELOOP
+  - EROFS
+  - ETXTBSY
+  - EACCES
+  - EFAULT
+  - EIO
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/execve.yml
+++ b/src/module/codegen/freebsd/execve.yml
@@ -1,0 +1,17 @@
+proto: struct thread *td, struct execve_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOEXEC
+  - ENOENT
+  - ELOOP
+  - EACCES
+  - ENOEXEC
+  - ETXTBSY
+  - ENOMEM
+  - E2BIG
+  - EFAULT
+  - EIO
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/faccessat.yml
+++ b/src/module/codegen/freebsd/faccessat.yml
@@ -1,0 +1,18 @@
+proto: struct thread *td, struct faccessat_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - ELOOP
+  - EROFS
+  - ETXTBSY
+  - EACCES
+  - EFAULT
+  - EIO
+  - EBADF
+  - EINVAL
+  - ENOTDIR
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/fchdir.yml
+++ b/src/module/codegen/freebsd/fchdir.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct fchdir_args *uap
+parms: td, uap
+errors:
+  - EACCES
+  - ENOTDIR
+  - EBADF
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/fchflags.yml
+++ b/src/module/codegen/freebsd/fchflags.yml
@@ -1,0 +1,11 @@
+proto: struct thread *td, struct fchflags_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EINVAL
+  - EPERM
+  - EROFS
+  - EIO
+  - EOPNOTSUPP
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/fchmod.yml
+++ b/src/module/codegen/freebsd/fchmod.yml
@@ -1,0 +1,9 @@
+proto: struct thread *td, struct fchmod_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EINVAL
+  - EROFS
+  - EIO
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/fchmodat.yml
+++ b/src/module/codegen/freebsd/fchmodat.yml
@@ -1,0 +1,18 @@
+proto: struct thread *td, struct fchmodat_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EINVAL
+  - ENOTDIR
+  - EACCES
+  - ELOOP
+  - EPERM
+  - EROFS
+  - EFAULT
+  - EIO
+  - EFTYPE 
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/fchown.yml
+++ b/src/module/codegen/freebsd/fchown.yml
@@ -1,0 +1,10 @@
+proto: struct thread *td, struct fchown_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EINVAL
+  - EPERM
+  - EROFS
+  - EIO
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/fchownat.yml
+++ b/src/module/codegen/freebsd/fchownat.yml
@@ -1,0 +1,17 @@
+proto: struct thread *td, struct fchownat_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - EBADF
+  - ENOTDIR
+  - EINVAL
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EPERM
+  - EROFS
+  - EFAULT
+  - EIO
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/fcntl.yml
+++ b/src/module/codegen/freebsd/fcntl.yml
@@ -1,0 +1,17 @@
+proto: struct thread *td, struct fcntl_args *uap
+parms: td, uap
+errors:
+  - EAGAIN
+  - EBADF
+  - EDEADLK
+  - EINTR
+  - EINVAL
+  - EMFILE
+  - ENOTTY
+  - ENOLCK
+  - EOPNOTSUPP
+  - EOVERFLOW
+  - EPERM
+  - ESRCH
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/fdatasync.yml
+++ b/src/module/codegen/freebsd/fdatasync.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct fdatasync_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EINVAL
+  - EIO
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/fexecve.yml
+++ b/src/module/codegen/freebsd/fexecve.yml
@@ -1,0 +1,18 @@
+proto: struct thread *td, struct fexecve_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOEXEC
+  - ENOENT
+  - ELOOP
+  - EACCES
+  - ENOEXEC
+  - ETXTBSY
+  - ENOMEM
+  - E2BIG
+  - EFAULT
+  - EIO
+  - EBADF
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/ffclock_getcounter.yml
+++ b/src/module/codegen/freebsd/ffclock_getcounter.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct ffclock_getcounter_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EPERM
+profiles:
+  - time

--- a/src/module/codegen/freebsd/ffclock_getestimate.yml
+++ b/src/module/codegen/freebsd/ffclock_getestimate.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct ffclock_getestimate_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EPERM
+profiles:
+  - time

--- a/src/module/codegen/freebsd/ffclock_setestimate.yml
+++ b/src/module/codegen/freebsd/ffclock_setestimate.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct ffclock_setestimate_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EPERM
+profiles:
+  - time

--- a/src/module/codegen/freebsd/fhopen.yml
+++ b/src/module/codegen/freebsd/fhopen.yml
@@ -1,0 +1,32 @@
+proto: struct thread *td, struct fhopen_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - EPERM
+  - ELOOP
+  - EISDIR
+  - EROFS
+  - ENFILE
+  - EMLINK
+  - ENXIO
+  - EINTR
+  - EOPNOTSUPP
+  - EWOULDBLOCK
+  - ENOSPC
+  - EDQUOT
+  - EIO
+  - ETXTBSY
+  - EFAULT
+  - EEXIST
+  - EBADF
+  - ENOTDIR
+  - ECAPMODE
+  - ENOTCAPABLE
+  - EINVAL
+  - ESTALE
+  - EOVERFLOW
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/fhstat.yml
+++ b/src/module/codegen/freebsd/fhstat.yml
@@ -1,0 +1,32 @@
+proto: struct thread *td, struct fhstat_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - EPERM
+  - ELOOP
+  - EISDIR
+  - EROFS
+  - ENFILE
+  - EMLINK
+  - ENXIO
+  - EINTR
+  - EOPNOTSUPP
+  - EWOULDBLOCK
+  - ENOSPC
+  - EDQUOT
+  - EIO
+  - ETXTBSY
+  - EFAULT
+  - EEXIST
+  - EBADF
+  - ENOTDIR
+  - ECAPMODE
+  - ENOTCAPABLE
+  - EINVAL
+  - ESTALE
+  - EOVERFLOW
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/fhstatfs.yml
+++ b/src/module/codegen/freebsd/fhstatfs.yml
@@ -1,0 +1,32 @@
+proto: struct thread *td, struct fhstatfs_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - EPERM
+  - ELOOP
+  - EISDIR
+  - EROFS
+  - ENFILE
+  - EMLINK
+  - ENXIO
+  - EINTR
+  - EOPNOTSUPP
+  - EWOULDBLOCK
+  - ENOSPC
+  - EDQUOT
+  - EIO
+  - ETXTBSY
+  - EFAULT
+  - EEXIST
+  - EBADF
+  - ENOTDIR
+  - ECAPMODE
+  - ENOTCAPABLE
+  - EINVAL
+  - ESTALE
+  - EOVERFLOW
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/flock.yml
+++ b/src/module/codegen/freebsd/flock.yml
@@ -1,0 +1,10 @@
+proto: struct thread *td, struct flock_args *uap
+parms: td, uap
+errors:
+  - EWOULDBLOCK
+  - EBADF
+  - EINVAL
+  - EOPNOTSUPP
+  - ENOLCK
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/fork.yml
+++ b/src/module/codegen/freebsd/fork.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct fork_args *uap
+parms: td, uap
+errors:
+  - EAGAIN
+  - ENOMEM
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/fpathconf.yml
+++ b/src/module/codegen/freebsd/fpathconf.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct fpathconf_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EBADF
+  - EIO
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/fstat.yml
+++ b/src/module/codegen/freebsd/fstat.yml
@@ -1,0 +1,9 @@
+proto: struct thread *td, struct fstat_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EFAULT
+  - EIO
+  - EOVERFLOW
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/fstatat.yml
+++ b/src/module/codegen/freebsd/fstatat.yml
@@ -1,0 +1,15 @@
+proto: struct thread *td, struct fstatat_args *uap
+parms: td, uap
+errors:
+  - EACCES
+  - EFAULT
+  - EIO
+  - ELOOP
+  - ENAMETOOLONG
+  - ENOENT
+  - ENOTDIR
+  - EOVERFLOW
+  - EBADF
+  - EINVAL
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/fstatfs.yml
+++ b/src/module/codegen/freebsd/fstatfs.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct fstatfs_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EFAULT
+  - EIO
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/fsync.yml
+++ b/src/module/codegen/freebsd/fsync.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct fsync_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EINVAL
+  - EIO
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/ftruncate.yml
+++ b/src/module/codegen/freebsd/ftruncate.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct ftruncate_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EINVAL
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/futimens.yml
+++ b/src/module/codegen/freebsd/futimens.yml
@@ -1,0 +1,13 @@
+proto: struct thread *td, struct futimens_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EINVAL
+  - EIO
+  - EPERM
+  - EACCES
+  - EPERM
+  - EROFS
+  - EBADF
+profiles:
+  - time

--- a/src/module/codegen/freebsd/futimes.yml
+++ b/src/module/codegen/freebsd/futimes.yml
@@ -1,0 +1,17 @@
+proto: struct thread *td, struct futimes_args *uap
+parms: td, uap
+errors:
+  - EACCES
+  - EFAULT
+  - EINVAL
+  - EIO
+  - ELOOP
+  - ENAMETOOLONG
+  - ENOENT
+  - ENOTDIR
+  - EPERM
+  - EPERM
+  - EROFS
+  - EBADF
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/futimesat.yml
+++ b/src/module/codegen/freebsd/futimesat.yml
@@ -1,0 +1,16 @@
+proto: struct thread *td, struct futimesat_args *uap
+parms: td, uap
+errors:
+  - EACCES
+  - EFAULT
+  - EINVAL
+  - EIO
+  - ELOOP
+  - ENAMETOOLONG
+  - ENOENT
+  - ENOTDIR
+  - EPERM
+  - EPERM
+  - EROFS
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/getaudit.yml
+++ b/src/module/codegen/freebsd/getaudit.yml
@@ -1,0 +1,10 @@
+proto: struct thread *td, struct getaudit_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EINVAL
+  - EPERM
+  - EOVERFLOW
+  - E2BIG
+profiles:
+  - security

--- a/src/module/codegen/freebsd/getauid.yml
+++ b/src/module/codegen/freebsd/getauid.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct getauid_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EPERM
+profiles:
+  - security

--- a/src/module/codegen/freebsd/getdirentries.yml
+++ b/src/module/codegen/freebsd/getdirentries.yml
@@ -1,0 +1,9 @@
+proto: struct thread *td, struct getdirentries_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EFAULT
+  - EINVAL
+  - EIO
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/getfh.yml
+++ b/src/module/codegen/freebsd/getfh.yml
@@ -1,0 +1,12 @@
+proto: struct thread *td, struct getfh_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EFAULT
+  - EIO
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/getfsstat.yml
+++ b/src/module/codegen/freebsd/getfsstat.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct getfsstat_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EINVAL
+  - EIO
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/getgroups.yml
+++ b/src/module/codegen/freebsd/getgroups.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct getgroups_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EFAULT
+profiles:
+  - user

--- a/src/module/codegen/freebsd/getitimer.yml
+++ b/src/module/codegen/freebsd/getitimer.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct getitimer_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EINVAL
+profiles:
+  - time

--- a/src/module/codegen/freebsd/getlogin.yml
+++ b/src/module/codegen/freebsd/getlogin.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct getlogin_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EINVAL
+  - EPERM
+  - ERANGE

--- a/src/module/codegen/freebsd/getloginclass.yml
+++ b/src/module/codegen/freebsd/getloginclass.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct getloginclass_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EINVAL
+  - EPERM
+  - ENAMETOOLONG

--- a/src/module/codegen/freebsd/getpeername.yml
+++ b/src/module/codegen/freebsd/getpeername.yml
@@ -1,0 +1,12 @@
+proto: struct thread *td, struct getpeername_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - ECONNRESET
+  - EINVAL
+  - ENOTSOCK
+  - ENOTCONN
+  - ENOBUFS
+  - EFAULT
+profiles:
+  - net

--- a/src/module/codegen/freebsd/getpgid.yml
+++ b/src/module/codegen/freebsd/getpgid.yml
@@ -1,0 +1,4 @@
+proto: struct thread *td, struct getpgid_args *uap
+parms: td, uap
+errors:
+  - ESRCH

--- a/src/module/codegen/freebsd/getpriority.yml
+++ b/src/module/codegen/freebsd/getpriority.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct getpriority_args *uap
+parms: td, uap
+errors:
+  - ESRCH
+  - EINVAL
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/getrandom.yml
+++ b/src/module/codegen/freebsd/getrandom.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct getrandom_args *uap
+parms: td, uap
+errors:
+  - EAGAIN
+  - EFAULT
+  - EINTR
+  - EINVAL

--- a/src/module/codegen/freebsd/getresgid.yml
+++ b/src/module/codegen/freebsd/getresgid.yml
@@ -1,0 +1,5 @@
+proto: struct thread *td, struct getresgid_args *uap
+parms: td, uap
+errors:
+  - EPERM
+  - EFAULT

--- a/src/module/codegen/freebsd/getresuid.yml
+++ b/src/module/codegen/freebsd/getresuid.yml
@@ -1,0 +1,5 @@
+proto: struct thread *td, struct getresuid_args *uap
+parms: td, uap
+errors:
+  - EPERM
+  - EFAULT

--- a/src/module/codegen/freebsd/getrusage.yml
+++ b/src/module/codegen/freebsd/getrusage.yml
@@ -1,0 +1,5 @@
+proto: struct thread *td, struct getrusage_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EFAULT

--- a/src/module/codegen/freebsd/getsid.yml
+++ b/src/module/codegen/freebsd/getsid.yml
@@ -1,0 +1,6 @@
+proto: struct thread *td, struct getsid_args *uap
+parms: td, uap
+errors:
+  - ESRCH
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/getsockname.yml
+++ b/src/module/codegen/freebsd/getsockname.yml
@@ -1,0 +1,11 @@
+proto: struct thread *td, struct getsockname_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - ECONNRESET
+  - EINVAL
+  - ENOTSOCK
+  - ENOBUFS
+  - EFAULT
+profiles:
+  - net

--- a/src/module/codegen/freebsd/getsockopt.yml
+++ b/src/module/codegen/freebsd/getsockopt.yml
@@ -1,0 +1,11 @@
+proto: struct thread *td, struct getsockopt_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - ENOTSOCK
+  - ENOPROTOOPT
+  - EFAULT
+  - EINVAL
+  - ENOMEM
+profiles:
+  - net

--- a/src/module/codegen/freebsd/gettimeofday.yml
+++ b/src/module/codegen/freebsd/gettimeofday.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct gettimeofday_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EPERM
+profiles:
+  - time

--- a/src/module/codegen/freebsd/ioctl.yml
+++ b/src/module/codegen/freebsd/ioctl.yml
@@ -1,0 +1,9 @@
+proto: struct thread *td, struct ioctl_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - ENOTTY
+  - EINVAL
+  - EFAULT
+profiles:
+  - io

--- a/src/module/codegen/freebsd/jail.yml
+++ b/src/module/codegen/freebsd/jail.yml
@@ -1,0 +1,16 @@
+proto: struct thread *td, struct jail_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - EPERM
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EFAULT
+  - EIO
+  - EFAULT
+  - EINVAL
+  - EAGAIN
+profiles:
+  - security

--- a/src/module/codegen/freebsd/jail_attach.yml
+++ b/src/module/codegen/freebsd/jail_attach.yml
@@ -1,0 +1,14 @@
+proto: struct thread *td, struct jail_attach_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - EPERM
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EFAULT
+  - EIO
+  - EINVAL
+profiles:
+  - security

--- a/src/module/codegen/freebsd/jail_get.yml
+++ b/src/module/codegen/freebsd/jail_get.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct jail_get_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - ENOENT
+  - EINVAL
+profiles:
+  - security

--- a/src/module/codegen/freebsd/jail_remove.yml
+++ b/src/module/codegen/freebsd/jail_remove.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct jail_remove_args *uap
+parms: td, uap
+errors:
+  - EPERM
+  - EINVAL
+profiles:
+  - security

--- a/src/module/codegen/freebsd/jail_set.yml
+++ b/src/module/codegen/freebsd/jail_set.yml
@@ -1,0 +1,14 @@
+proto: struct thread *td, struct jail_set_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - EPERM
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EFAULT
+  - EIO
+  - EINVAL
+profiles:
+  - security

--- a/src/module/codegen/freebsd/kenv.yml
+++ b/src/module/codegen/freebsd/kenv.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct kenv_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - ENOENT
+  - EPERM
+  - EFAULT
+  - ENAMETOOLONG

--- a/src/module/codegen/freebsd/kevent.yml
+++ b/src/module/codegen/freebsd/kevent.yml
@@ -1,0 +1,12 @@
+proto: struct thread *td, struct kevent_args *uap
+parms: td, uap
+errors:
+  - EACCES
+  - EFAULT
+  - EBADF
+  - EINTR
+  - EINTR
+  - EINVAL
+  - ENOENT
+  - ENOMEM
+  - ESRCH

--- a/src/module/codegen/freebsd/kill.yml
+++ b/src/module/codegen/freebsd/kill.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct kill_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - ESRCH
+  - EPERM
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/kqueue.yml
+++ b/src/module/codegen/freebsd/kqueue.yml
@@ -1,0 +1,6 @@
+proto: struct thread *td, struct kqueue_args *uap
+parms: td, uap
+errors:
+  - ENOMEM
+  - EMFILE
+  - ENFILE

--- a/src/module/codegen/freebsd/lchflags.yml
+++ b/src/module/codegen/freebsd/lchflags.yml
@@ -1,0 +1,15 @@
+proto: struct thread *td, struct lchflags_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EPERM
+  - EROFS
+  - EFAULT
+  - EIO
+  - EOPNOTSUPP
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/lchmod.yml
+++ b/src/module/codegen/freebsd/lchmod.yml
@@ -1,0 +1,15 @@
+proto: struct thread *td, struct lchmod_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EPERM
+  - EROFS
+  - EFAULT
+  - EIO
+  - EFTYPE
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/lchown.yml
+++ b/src/module/codegen/freebsd/lchown.yml
@@ -1,0 +1,14 @@
+proto: struct thread *td, struct lchown_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EPERM
+  - EROFS
+  - EFAULT
+  - EIO
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/lgetfh.yml
+++ b/src/module/codegen/freebsd/lgetfh.yml
@@ -1,0 +1,12 @@
+proto: struct thread *td, struct lgetfh_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EFAULT
+  - EIO
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/link.yml
+++ b/src/module/codegen/freebsd/link.yml
@@ -1,0 +1,21 @@
+proto: struct thread *td, struct link_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EOPNOTSUPP
+  - EMLINK
+  - EACCES
+  - ENOENT
+  - EEXIST
+  - EPERM
+  - EXDEV
+  - ENOSPC
+  - EDQUOT
+  - ELOOP
+  - EIO
+  - EROFS
+  - EFAULT
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/linkat.yml
+++ b/src/module/codegen/freebsd/linkat.yml
@@ -1,0 +1,24 @@
+proto: struct thread *td, struct linkat_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EOPNOTSUPP
+  - EMLINK
+  - EACCES
+  - ENOENT
+  - EEXIST
+  - EPERM
+  - EXDEV
+  - ENOSPC
+  - EDQUOT
+  - ELOOP
+  - EIO
+  - EROFS
+  - EFAULT
+  - EBADF
+  - EINVAL
+  - ENOTDIR
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/lio_listio.yml
+++ b/src/module/codegen/freebsd/lio_listio.yml
@@ -1,0 +1,14 @@
+proto: struct thread *td, struct lio_listio_args *uap
+parms: td, uap
+errors:
+  - EAGAIN
+  - EINVAL
+  - EINTR
+  - EIO
+  - EAGAIN
+  - EOPNOTSUPP
+  - EBADF
+  - EOVERFLOW
+  - ECANCELED
+profiles:
+  - io

--- a/src/module/codegen/freebsd/listen.yml
+++ b/src/module/codegen/freebsd/listen.yml
@@ -1,0 +1,10 @@
+proto: struct thread *td, struct listen_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EDESTADDRREQ
+  - EINVAL
+  - ENOTSOCK
+  - EOPNOTSUPP
+profiles:
+  - net

--- a/src/module/codegen/freebsd/lpathconf.yml
+++ b/src/module/codegen/freebsd/lpathconf.yml
@@ -1,0 +1,11 @@
+proto: struct thread *td, struct lpathconf_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EIO
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/lseek.yml
+++ b/src/module/codegen/freebsd/lseek.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct lseek_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EINVAL
+  - ENXIO
+  - EOVERFLOW
+  - ESPIPE

--- a/src/module/codegen/freebsd/lutimes.yml
+++ b/src/module/codegen/freebsd/lutimes.yml
@@ -1,0 +1,15 @@
+proto: struct thread *td, struct lutimes_args *uap
+parms: td, uap
+errors:
+  - EACCES
+  - EFAULT
+  - EINVAL
+  - EIO
+  - ELOOP
+  - ENAMETOOLONG
+  - ENOENT
+  - ENOTDIR
+  - EPERM
+  - EROFS
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/madvise.yml
+++ b/src/module/codegen/freebsd/madvise.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct madvise_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - ENOMEM
+  - EPERM
+profiles:
+  - mem

--- a/src/module/codegen/freebsd/mincore.yml
+++ b/src/module/codegen/freebsd/mincore.yml
@@ -1,0 +1,5 @@
+proto: struct thread *td, struct mincore_args *uap
+parms: td, uap
+errors:
+  - ENOMEM
+  - EFAULT

--- a/src/module/codegen/freebsd/minherit.yml
+++ b/src/module/codegen/freebsd/minherit.yml
@@ -1,0 +1,5 @@
+proto: struct thread *td, struct minherit_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EACCES

--- a/src/module/codegen/freebsd/mkdir.yml
+++ b/src/module/codegen/freebsd/mkdir.yml
@@ -1,0 +1,17 @@
+proto: struct thread *td, struct mkdir_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EPERM
+  - EROFS
+  - EEXIST
+  - ENOSPC
+  - EDQUOT
+  - EIO
+  - EFAULT
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/mkdirat.yml
+++ b/src/module/codegen/freebsd/mkdirat.yml
@@ -1,0 +1,19 @@
+proto: struct thread *td, struct mkdirat_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EPERM
+  - EROFS
+  - EEXIST
+  - ENOSPC
+  - EDQUOT
+  - EIO
+  - EFAULT
+  - EBADF
+  - ENOTDIR
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/mkfifo.yml
+++ b/src/module/codegen/freebsd/mkfifo.yml
@@ -1,0 +1,16 @@
+proto: struct thread *td, struct mkfifo_args *uap
+parms: td, uap
+errors:
+  - ENOTSUP
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EROFS
+  - EEXIST
+  - EPERM
+  - ENOSPC
+  - EDQUOT
+  - EIO
+  - EFAULT

--- a/src/module/codegen/freebsd/mkfifoat.yml
+++ b/src/module/codegen/freebsd/mkfifoat.yml
@@ -1,0 +1,17 @@
+proto: struct thread *td, struct mkfifoat_args *uap
+parms: td, uap
+errors:
+  - ENOTSUP
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EROFS
+  - EEXIST
+  - EPERM
+  - ENOSPC
+  - EDQUOT
+  - EIO
+  - EFAULT
+  - EBADF

--- a/src/module/codegen/freebsd/mknodat.yml
+++ b/src/module/codegen/freebsd/mknodat.yml
@@ -1,0 +1,17 @@
+proto: struct thread *td, struct mknodat_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EPERM
+  - EIO
+  - ENOSPC
+  - EDQUOT
+  - EROFS
+  - EEXIST
+  - EFAULT
+  - EINVAL
+  - EBADF

--- a/src/module/codegen/freebsd/mlock.yml
+++ b/src/module/codegen/freebsd/mlock.yml
@@ -1,0 +1,9 @@
+proto: struct thread *td, struct mlock_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EAGAIN
+  - ENOMEM
+  - EPERM
+profiles:
+  - mem

--- a/src/module/codegen/freebsd/mlockall.yml
+++ b/src/module/codegen/freebsd/mlockall.yml
@@ -1,0 +1,9 @@
+proto: struct thread *td, struct mlockall_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - ENOMEM
+  - EAGAIN
+  - EPERM
+profiles:
+  - mem

--- a/src/module/codegen/freebsd/mmap.yml
+++ b/src/module/codegen/freebsd/mmap.yml
@@ -1,0 +1,9 @@
+proto: struct thread *td, struct mmap_args *uap
+parms: td, uap
+errors:
+  - EACCES
+  - EBADF
+  - EINVAL
+  - ENOMEM
+profiles:
+  - mem

--- a/src/module/codegen/freebsd/modfind.yml
+++ b/src/module/codegen/freebsd/modfind.yml
@@ -1,0 +1,5 @@
+proto: struct thread *td, struct modfind_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - ENOENT

--- a/src/module/codegen/freebsd/modstat.yml
+++ b/src/module/codegen/freebsd/modstat.yml
@@ -1,0 +1,6 @@
+proto: struct thread *td, struct modstat_args *uap
+parms: td, uap
+errors:
+  - ENOENT
+  - EINVAL
+  - EFAULT

--- a/src/module/codegen/freebsd/mount.yml
+++ b/src/module/codegen/freebsd/mount.yml
@@ -1,0 +1,22 @@
+proto: struct thread *td, struct mount_args *uap
+parms: td, uap
+errors:
+  - EPERM
+  - ENAMETOOLONG
+  - ELOOP
+  - ENOENT
+  - ENOTDIR
+  - EBUSY
+  - EFAULT
+  - ENODEV
+  - ENOTBLK
+  - ENXIO
+  - EBUSY
+  - EMFILE
+  - EINVAL
+  - ENOMEM
+  - EIO
+  - EFAULT
+  - ETIMEDOUT
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/mprotect.yml
+++ b/src/module/codegen/freebsd/mprotect.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct mprotect_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EACCES
+profiles:
+  - mem

--- a/src/module/codegen/freebsd/msgctl.yml
+++ b/src/module/codegen/freebsd/msgctl.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct msgctl_args *uap
+parms: td, uap
+errors:
+  - EPERM
+  - EACCES
+  - EINVAL
+  - EFAULT

--- a/src/module/codegen/freebsd/msgget.yml
+++ b/src/module/codegen/freebsd/msgget.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct msgget_args *uap
+parms: td, uap
+errors:
+  - EACCES
+  - EEXIST
+  - ENOSPC
+  - ENOENT

--- a/src/module/codegen/freebsd/msgrcv.yml
+++ b/src/module/codegen/freebsd/msgrcv.yml
@@ -1,0 +1,9 @@
+proto: struct thread *td, struct msgrcv_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - E2BIG
+  - EACCES
+  - EFAULT
+  - EINTR
+  - ENOMSG

--- a/src/module/codegen/freebsd/msgsnd.yml
+++ b/src/module/codegen/freebsd/msgsnd.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct msgsnd_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EACCES
+  - EAGAIN
+  - EFAULT
+  - EINTR

--- a/src/module/codegen/freebsd/msync.yml
+++ b/src/module/codegen/freebsd/msync.yml
@@ -1,0 +1,10 @@
+proto: struct thread *td, struct msync_args *uap
+parms: td, uap
+errors:
+  - EBUSY
+  - EINVAL
+  - ENOMEM
+  - EINVAL
+  - EIO
+profiles:
+  - mem

--- a/src/module/codegen/freebsd/munlock.yml
+++ b/src/module/codegen/freebsd/munlock.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct munlock_args *uap
+parms: td, uap
+errors:
+  - EPERM
+  - EINVAL
+  - ENOMEM
+profiles:
+  - mem

--- a/src/module/codegen/freebsd/munlockall.yml
+++ b/src/module/codegen/freebsd/munlockall.yml
@@ -1,0 +1,9 @@
+proto: struct thread *td, struct munlockall_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - ENOMEM
+  - EAGAIN
+  - EPERM
+profiles:
+  - mem

--- a/src/module/codegen/freebsd/munmap.yml
+++ b/src/module/codegen/freebsd/munmap.yml
@@ -1,0 +1,6 @@
+proto: struct thread *td, struct munmap_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+profiles:
+  - mem

--- a/src/module/codegen/freebsd/nanosleep.yml
+++ b/src/module/codegen/freebsd/nanosleep.yml
@@ -1,0 +1,11 @@
+proto: struct thread *td, struct nanosleep_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EINTR
+  - EINVAL
+  - EINVAL
+  - EINVAL
+  - ENOTSUP
+profiles:
+  - time

--- a/src/module/codegen/freebsd/nfssvc.yml
+++ b/src/module/codegen/freebsd/nfssvc.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct nfssvc_args *uap
+parms: td, uap
+errors:
+  - ENEEDAUTH
+  - EPERM
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/nmount.yml
+++ b/src/module/codegen/freebsd/nmount.yml
@@ -1,0 +1,22 @@
+proto: struct thread *td, struct nmount_args *uap
+parms: td, uap
+errors:
+  - EPERM
+  - ENAMETOOLONG
+  - ELOOP
+  - ENOENT
+  - ENOTDIR
+  - EBUSY
+  - EFAULT
+  - ENODEV
+  - ENOTBLK
+  - ENXIO
+  - EBUSY
+  - EMFILE
+  - EINVAL
+  - ENOMEM
+  - EIO
+  - EFAULT
+  - ETIMEDOUT
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/open.yml
+++ b/src/module/codegen/freebsd/open.yml
@@ -1,0 +1,31 @@
+proto: struct thread *td, struct open_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - EPERM
+  - ELOOP
+  - EISDIR
+  - EROFS
+  - EMFILE
+  - ENFILE
+  - EMLINK
+  - ENXIO
+  - EINTR
+  - EOPNOTSUPP
+  - EWOULDBLOCK
+  - ENOSPC
+  - EDQUOT
+  - EIO
+  - ETXTBSY
+  - EFAULT
+  - EEXIST
+  - EINVAL
+  - EBADF
+  - ENOTDIR
+  - ECAPMODE
+  - ENOTCAPABLE
+profiles:
+  - io

--- a/src/module/codegen/freebsd/openat.yml
+++ b/src/module/codegen/freebsd/openat.yml
@@ -1,0 +1,31 @@
+proto: struct thread *td, struct openat_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - EPERM
+  - ELOOP
+  - EISDIR
+  - EROFS
+  - EMFILE
+  - ENFILE
+  - EMLINK
+  - ENXIO
+  - EINTR
+  - EOPNOTSUPP
+  - EWOULDBLOCK
+  - ENOSPC
+  - EDQUOT
+  - EIO
+  - ETXTBSY
+  - EFAULT
+  - EEXIST
+  - EINVAL
+  - EBADF
+  - ENOTDIR
+  - ECAPMODE
+  - ENOTCAPABLE
+profiles:
+  - io

--- a/src/module/codegen/freebsd/pathconf.yml
+++ b/src/module/codegen/freebsd/pathconf.yml
@@ -1,0 +1,12 @@
+proto: struct thread *td, struct pathconf_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EIO
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/pdfork.yml
+++ b/src/module/codegen/freebsd/pdfork.yml
@@ -1,0 +1,9 @@
+proto: struct thread *td, struct pdfork_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - ENOTCAPABLE
+  - EAGAIN
+  - ENOMEM
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/pdgetpid.yml
+++ b/src/module/codegen/freebsd/pdgetpid.yml
@@ -1,0 +1,5 @@
+proto: struct thread *td, struct pdgetpid_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - ENOTCAPABLE

--- a/src/module/codegen/freebsd/pdkill.yml
+++ b/src/module/codegen/freebsd/pdkill.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct pdkill_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - ENOTCAPABLE
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/pipe2.yml
+++ b/src/module/codegen/freebsd/pipe2.yml
@@ -1,0 +1,10 @@
+proto: struct thread *td, struct pipe2_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EMFILE
+  - ENFILE
+  - ENOMEM
+  - EINVAL
+profiles:
+  - ipc

--- a/src/module/codegen/freebsd/poll.yml
+++ b/src/module/codegen/freebsd/poll.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct poll_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EINTR
+  - EINVAL
+profiles:
+  - io

--- a/src/module/codegen/freebsd/posix_fadvise.yml
+++ b/src/module/codegen/freebsd/posix_fadvise.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct posix_fadvise_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EINVAL
+  - EINVAL
+  - ENODEV
+  - ESPIPE

--- a/src/module/codegen/freebsd/posix_fallocate.yml
+++ b/src/module/codegen/freebsd/posix_fallocate.yml
@@ -1,0 +1,12 @@
+proto: struct thread *td, struct posix_fallocate_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EFBIG
+  - EINTR
+  - EINVAL
+  - EIO
+  - ENODEV
+  - ENOSPC
+  - ENOTCAPABLE
+  - ESPIPE

--- a/src/module/codegen/freebsd/posix_openpt.yml
+++ b/src/module/codegen/freebsd/posix_openpt.yml
@@ -1,0 +1,6 @@
+proto: struct thread *td, struct posix_openpt_args *uap
+parms: td, uap
+errors:
+  - ENFILE
+  - EINVAL
+  - EAGAIN

--- a/src/module/codegen/freebsd/ppoll.yml
+++ b/src/module/codegen/freebsd/ppoll.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct ppoll_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EINTR
+  - EINVAL
+profiles:
+  - io

--- a/src/module/codegen/freebsd/pread.yml
+++ b/src/module/codegen/freebsd/pread.yml
@@ -1,0 +1,16 @@
+proto: struct thread *td, struct pread_args *uap
+parms: td, uap
+errors:
+  - ECONNRESET
+  - EFAULT
+  - EIO
+  - EBUSY
+  - EINTR
+  - EINVAL
+  - EAGAIN
+  - EISDIR
+  - EOPNOTSUPP
+  - EOVERFLOW
+  - ESPIPE
+profiles:
+  - io

--- a/src/module/codegen/freebsd/preadv.yml
+++ b/src/module/codegen/freebsd/preadv.yml
@@ -1,0 +1,17 @@
+proto: struct thread *td, struct preadv_args *uap
+parms: td, uap
+errors:
+  - ECONNRESET
+  - EFAULT
+  - EIO
+  - EBUSY
+  - EINTR
+  - EINVAL
+  - EAGAIN
+  - EISDIR
+  - EOPNOTSUPP
+  - EOVERFLOW 
+  - EFAULT
+  - ESPIPE
+profiles:
+  - io

--- a/src/module/codegen/freebsd/procctl.yml
+++ b/src/module/codegen/freebsd/procctl.yml
@@ -1,0 +1,11 @@
+proto: struct thread *td, struct procctl_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EINVAL
+  - EPERM
+  - ESRCH
+  - EINVAL
+  - EBUSY
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/profil.yml
+++ b/src/module/codegen/freebsd/profil.yml
@@ -1,0 +1,4 @@
+proto: struct thread *td, struct profil_args *uap
+parms: td, uap
+errors:
+  - EFAULT

--- a/src/module/codegen/freebsd/pselect.yml
+++ b/src/module/codegen/freebsd/pselect.yml
@@ -1,0 +1,10 @@
+proto: struct thread *td, struct pselect_args *uap
+parms: td, uap
+errors:
+errors:
+  - EBADF
+  - EFAULT
+  - EINTR
+  - EINVAL
+profiles:
+  - io

--- a/src/module/codegen/freebsd/ptrace.yml
+++ b/src/module/codegen/freebsd/ptrace.yml
@@ -1,0 +1,11 @@
+proto: struct thread *td, struct ptrace_args *uap
+parms: td, uap
+errors:
+  - ESRCH
+  - EINVAL
+  - EBUSY
+  - EPERM
+  - ENOENT
+  - ENAMETOOLONG
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/pwrite.yml
+++ b/src/module/codegen/freebsd/pwrite.yml
@@ -1,0 +1,16 @@
+proto: struct thread *td, struct pwrite_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EPIPE
+  - EFBIG
+  - EFAULT
+  - EINVAL
+  - ENOSPC
+  - EDQUOT
+  - EIO
+  - EINTR
+  - EAGAIN
+  - EROFS
+profiles:
+  - io

--- a/src/module/codegen/freebsd/pwritev.yml
+++ b/src/module/codegen/freebsd/pwritev.yml
@@ -1,0 +1,19 @@
+proto: struct thread *td, struct pwritev_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EPIPE
+  - EFBIG
+  - EFAULT
+  - EINVAL
+  - ENOSPC
+  - EDQUOT
+  - EIO
+  - EINTR
+  - EAGAIN
+  - EROFS
+  - EDESTADDRREQ
+  - ENOBUFS
+  - ESPIPE
+profiles:
+  - io

--- a/src/module/codegen/freebsd/quotactl.yml
+++ b/src/module/codegen/freebsd/quotactl.yml
@@ -1,0 +1,17 @@
+proto: struct thread *td, struct quotactl_args *uap
+parms: td, uap
+errors:
+  - EOPNOTSUPP
+  - EUSERS
+  - EINVAL
+  - EACCES
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - ELOOP
+  - EROFS
+  - EIO
+  - EFAULT
+  - EPERM
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/rctl_add_rule.yml
+++ b/src/module/codegen/freebsd/rctl_add_rule.yml
@@ -1,0 +1,11 @@
+proto: struct thread *td, struct rctl_add_rule_args *uap
+parms: td, uap
+errors:
+  - ENOSYS
+  - EINVAL
+  - EPERM
+  - E2BIG
+  - ESRCH
+  - ENAMETOOLONG
+  - ERANGE
+  - EOPNOTSUPP

--- a/src/module/codegen/freebsd/rctl_get_limits.yml
+++ b/src/module/codegen/freebsd/rctl_get_limits.yml
@@ -1,0 +1,11 @@
+proto: struct thread *td, struct rctl_get_limits_args *uap
+parms: td, uap
+errors:
+  - ENOSYS
+  - EINVAL
+  - EPERM
+  - E2BIG
+  - ESRCH
+  - ENAMETOOLONG
+  - ERANGE
+  - EOPNOTSUPP

--- a/src/module/codegen/freebsd/rctl_get_racct.yml
+++ b/src/module/codegen/freebsd/rctl_get_racct.yml
@@ -1,0 +1,11 @@
+proto: struct thread *td, struct rctl_get_racct_args *uap
+parms: td, uap
+errors:
+  - ENOSYS
+  - EINVAL
+  - EPERM
+  - E2BIG
+  - ESRCH
+  - ENAMETOOLONG
+  - ERANGE
+  - EOPNOTSUPP

--- a/src/module/codegen/freebsd/rctl_get_rules.yml
+++ b/src/module/codegen/freebsd/rctl_get_rules.yml
@@ -1,0 +1,11 @@
+proto: struct thread *td, struct rctl_get_rules_args *uap
+parms: td, uap
+errors:
+  - ENOSYS
+  - EINVAL
+  - EPERM
+  - E2BIG
+  - ESRCH
+  - ENAMETOOLONG
+  - ERANGE
+  - EOPNOTSUPP

--- a/src/module/codegen/freebsd/rctl_remove_rule.yml
+++ b/src/module/codegen/freebsd/rctl_remove_rule.yml
@@ -1,0 +1,11 @@
+proto: struct thread *td, struct rctl_remove_rule_args *uap
+parms: td, uap
+errors:
+  - ENOSYS
+  - EINVAL
+  - EPERM
+  - E2BIG
+  - ESRCH
+  - ENAMETOOLONG
+  - ERANGE
+  - EOPNOTSUPP

--- a/src/module/codegen/freebsd/readlink.yml
+++ b/src/module/codegen/freebsd/readlink.yml
@@ -1,0 +1,13 @@
+proto: struct thread *td, struct readlink_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EINVAL
+  - EIO
+  - EFAULT
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/readlinkat.yml
+++ b/src/module/codegen/freebsd/readlinkat.yml
@@ -1,0 +1,14 @@
+proto: struct thread *td, struct readlinkat_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EINVAL
+  - EIO
+  - EFAULT
+  - EBADF
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/readv.yml
+++ b/src/module/codegen/freebsd/readv.yml
@@ -1,0 +1,16 @@
+proto: struct thread *td, struct readv_args *uap
+parms: td, uap
+errors:
+  - ECONNRESET
+  - EFAULT
+  - EIO
+  - EBUSY
+  - EINTR
+  - EINVAL
+  - EAGAIN
+  - EISDIR
+  - EOPNOTSUPP
+  - EOVERFLOW
+  - EFAULT
+profiles:
+  - io

--- a/src/module/codegen/freebsd/reboot.yml
+++ b/src/module/codegen/freebsd/reboot.yml
@@ -1,0 +1,4 @@
+proto: struct thread *td, struct reboot_args *uap
+parms: td, uap
+errors:
+  - EPERM

--- a/src/module/codegen/freebsd/recvfrom.yml
+++ b/src/module/codegen/freebsd/recvfrom.yml
@@ -1,0 +1,13 @@
+proto: struct thread *td, struct recvfrom_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - ECONNRESET
+  - ENOTCONN
+  - ENOTSOCK
+  - EMSGSIZE
+  - EAGAIN
+  - EINTR
+  - EFAULT
+profiles:
+  - net

--- a/src/module/codegen/freebsd/recvmsg.yml
+++ b/src/module/codegen/freebsd/recvmsg.yml
@@ -1,0 +1,13 @@
+proto: struct thread *td, struct recvmsg_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - ECONNRESET
+  - ENOTCONN
+  - ENOTSOCK
+  - EMSGSIZE
+  - EAGAIN
+  - EINTR
+  - EFAULT
+profiles:
+  - net

--- a/src/module/codegen/freebsd/rename.yml
+++ b/src/module/codegen/freebsd/rename.yml
@@ -1,0 +1,20 @@
+proto: struct thread *td, struct rename_args *uap
+parms: td, uap
+errors:
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - EPERM
+  - ELOOP
+  - ENOTDIR
+  - EISDIR
+  - EXDEV
+  - ENOSPC
+  - EDQUOT
+  - EIO
+  - EFAULT
+  - EINVAL
+  - ENOTEMPTY
+  - ECAPMODE
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/renameat.yml
+++ b/src/module/codegen/freebsd/renameat.yml
@@ -1,0 +1,24 @@
+proto: struct thread *td, struct renameat_args *uap
+parms: td, uap
+errors:
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - EPERM
+  - ELOOP
+  - ENOTDIR
+  - EISDIR
+  - EXDEV
+  - ENOSPC
+  - EDQUOT
+  - EIO
+  - EFAULT
+  - EINVAL
+  - ENOTEMPTY
+  - ECAPMODE
+  - EBADF
+  - ENOTDIR
+  - ECAPMODE
+  - ENOTCAPABLE
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/revoke.yml
+++ b/src/module/codegen/freebsd/revoke.yml
@@ -1,0 +1,13 @@
+proto: struct thread *td, struct revoke_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EFAULT
+  - EINVAL
+  - EPERM
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/rfork.yml
+++ b/src/module/codegen/freebsd/rfork.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct rfork_args *uap
+parms: td, uap
+errors:
+  - EAGAIN
+  - EINVAL
+  - ENOMEM
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/rmdir.yml
+++ b/src/module/codegen/freebsd/rmdir.yml
@@ -1,0 +1,18 @@
+proto: struct thread *td, struct rmdir_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - ELOOP
+  - ENOTEMPTY
+  - EACCES
+  - EACCES
+  - EPERM
+  - EINVAL
+  - EBUSY
+  - EIO
+  - EROFS
+  - EFAULT
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/rtprio.yml
+++ b/src/module/codegen/freebsd/rtprio.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct rtprio_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EINVAL
+  - EPERM
+  - ESRCH

--- a/src/module/codegen/freebsd/rtprio_thread.yml
+++ b/src/module/codegen/freebsd/rtprio_thread.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct rtprio_thread_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EINVAL
+  - EPERM
+  - ESRCH

--- a/src/module/codegen/freebsd/sbrk.yml
+++ b/src/module/codegen/freebsd/sbrk.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct sbrk_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - ENOMEM
+profiles:
+  - mem

--- a/src/module/codegen/freebsd/sched_get_priority_max.yml
+++ b/src/module/codegen/freebsd/sched_get_priority_max.yml
@@ -1,0 +1,6 @@
+proto: struct thread *td, struct sched_get_priority_max_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - ENOSYS
+  - ESRCH

--- a/src/module/codegen/freebsd/sched_get_priority_min.yml
+++ b/src/module/codegen/freebsd/sched_get_priority_min.yml
@@ -1,0 +1,6 @@
+proto: struct thread *td, struct sched_get_priority_min_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - ENOSYS
+  - ESRCH

--- a/src/module/codegen/freebsd/sched_getparam.yml
+++ b/src/module/codegen/freebsd/sched_getparam.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct sched_getparam_args *uap
+parms: td, uap
+errors:
+  - ENOSYS
+  - EPERM
+  - ESRCH
+  - EINVAL

--- a/src/module/codegen/freebsd/sched_getscheduler.yml
+++ b/src/module/codegen/freebsd/sched_getscheduler.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct sched_getscheduler_args *uap
+parms: td, uap
+errors:
+  - ENOSYS
+  - EPERM
+  - ESRCH
+  - EINVAL

--- a/src/module/codegen/freebsd/sched_rr_get_interval.yml
+++ b/src/module/codegen/freebsd/sched_rr_get_interval.yml
@@ -1,0 +1,6 @@
+proto: struct thread *td, struct sched_rr_get_interval_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - ENOSYS
+  - ESRCH

--- a/src/module/codegen/freebsd/sched_setparam.yml
+++ b/src/module/codegen/freebsd/sched_setparam.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct sched_setparam_args *uap
+parms: td, uap
+errors:
+  - ENOSYS
+  - EPERM
+  - ESRCH
+  - EINVAL

--- a/src/module/codegen/freebsd/sched_setscheduler.yml
+++ b/src/module/codegen/freebsd/sched_setscheduler.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct sched_setscheduler_args *uap
+parms: td, uap
+errors:
+  - ENOSYS
+  - EPERM
+  - ESRCH
+  - EINVAL

--- a/src/module/codegen/freebsd/sched_yield.yml
+++ b/src/module/codegen/freebsd/sched_yield.yml
@@ -1,0 +1,6 @@
+proto: struct thread *td, struct sched_yield_args *uap
+parms: td, uap
+errors:
+  - ENOSYS
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/select.yml
+++ b/src/module/codegen/freebsd/select.yml
@@ -1,0 +1,9 @@
+proto: struct thread *td, struct select_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EFAULT
+  - EINTR
+  - EINVAL
+profiles:
+  - io

--- a/src/module/codegen/freebsd/semget.yml
+++ b/src/module/codegen/freebsd/semget.yml
@@ -1,0 +1,10 @@
+proto: struct thread *td, struct semget_args *uap
+parms: td, uap
+errors:
+  - EACCES
+  - EEXIST
+  - EINVAL
+  - ENOSPC
+  - ENOENT
+profiles:
+  - ipc

--- a/src/module/codegen/freebsd/semop.yml
+++ b/src/module/codegen/freebsd/semop.yml
@@ -1,0 +1,14 @@
+proto: struct thread *td, struct semop_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EACCES
+  - EAGAIN
+  - E2BIG
+  - EFBIG
+  - EIDRM
+  - EINTR
+  - ENOSPC
+  - ERANGE
+profiles:
+  - ipc

--- a/src/module/codegen/freebsd/sendfile.yml
+++ b/src/module/codegen/freebsd/sendfile.yml
@@ -1,0 +1,19 @@
+proto: struct thread *td, struct sendfile_args *uap
+parms: td, uap
+errors:
+  - EAGAIN
+  - EBADF
+  - EBUSY
+  - EFAULT
+  - EINTR
+  - EINVAL
+  - EINVAL
+  - EIO
+  - ENOTCAPABLE
+  - ENOBUFS
+  - ENOTCONN
+  - ENOTSOCK
+  - EOPNOTSUPP
+  - EPIPE
+profiles:
+  - net

--- a/src/module/codegen/freebsd/sendmsg.yml
+++ b/src/module/codegen/freebsd/sendmsg.yml
@@ -1,0 +1,19 @@
+proto: struct thread *td, struct sendmsg_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EACCES
+  - ENOTSOCK
+  - EFAULT
+  - EMSGSIZE
+  - EAGAIN
+  - ENOBUFS
+  - EHOSTUNREACH
+  - EISCONN
+  - ECONNREFUSED
+  - EHOSTDOWN
+  - ENETDOWN
+  - EADDRNOTAVAIL
+  - EPIPE
+profiles:
+  - net

--- a/src/module/codegen/freebsd/sendto.yml
+++ b/src/module/codegen/freebsd/sendto.yml
@@ -1,0 +1,19 @@
+proto: struct thread *td, struct sendto_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EACCES
+  - ENOTSOCK
+  - EFAULT
+  - EMSGSIZE
+  - EAGAIN
+  - ENOBUFS
+  - EHOSTUNREACH
+  - EISCONN
+  - ECONNREFUSED
+  - EHOSTDOWN
+  - ENETDOWN
+  - EADDRNOTAVAIL
+  - EPIPE
+profiles:
+  - net

--- a/src/module/codegen/freebsd/setegid.yml
+++ b/src/module/codegen/freebsd/setegid.yml
@@ -1,0 +1,4 @@
+proto: struct thread *td, struct setegid_args *uap
+parms: td, uap
+errors:
+  - EPERM

--- a/src/module/codegen/freebsd/seteuid.yml
+++ b/src/module/codegen/freebsd/seteuid.yml
@@ -1,0 +1,4 @@
+proto: struct thread *td, struct seteuid_args *uap
+parms: td, uap
+errors:
+  - EPERM

--- a/src/module/codegen/freebsd/setfib.yml
+++ b/src/module/codegen/freebsd/setfib.yml
@@ -1,0 +1,4 @@
+proto: struct thread *td, struct setfib_args *uap
+parms: td, uap
+errors:
+  - EPERM

--- a/src/module/codegen/freebsd/setgid.yml
+++ b/src/module/codegen/freebsd/setgid.yml
@@ -1,0 +1,4 @@
+proto: struct thread *td, struct setgid_args *uap
+parms: td, uap
+errors:
+  - EPERM

--- a/src/module/codegen/freebsd/setgroups.yml
+++ b/src/module/codegen/freebsd/setgroups.yml
@@ -1,0 +1,6 @@
+proto: struct thread *td, struct setgroups_args *uap
+parms: td, uap
+errors:
+  - EPERM
+  - EINVAL
+  - EFAULT

--- a/src/module/codegen/freebsd/setitimer.yml
+++ b/src/module/codegen/freebsd/setitimer.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct setitimer_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EINVAL
+profiles:
+  - time

--- a/src/module/codegen/freebsd/setlogin.yml
+++ b/src/module/codegen/freebsd/setlogin.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct setlogin_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EINVAL
+  - EPERM
+  - ERANGE

--- a/src/module/codegen/freebsd/setloginclass.yml
+++ b/src/module/codegen/freebsd/setloginclass.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct setloginclass_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EINVAL
+  - EPERM
+  - ENAMETOOLONG

--- a/src/module/codegen/freebsd/setpgid.yml
+++ b/src/module/codegen/freebsd/setpgid.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct setpgid_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - ESRCH
+  - ESRCH
+  - EACCES
+  - EPERM

--- a/src/module/codegen/freebsd/setpriority.yml
+++ b/src/module/codegen/freebsd/setpriority.yml
@@ -1,0 +1,9 @@
+proto: struct thread *td, struct setpriority_args *uap
+parms: td, uap
+errors:
+  - ESRCH
+  - EINVAL
+  - EPERM
+  - EACCES
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/setregid.yml
+++ b/src/module/codegen/freebsd/setregid.yml
@@ -1,0 +1,4 @@
+proto: struct thread *td, struct setregid_args *uap
+parms: td, uap
+errors:
+  - EPERM

--- a/src/module/codegen/freebsd/setresgid.yml
+++ b/src/module/codegen/freebsd/setresgid.yml
@@ -1,0 +1,5 @@
+proto: struct thread *td, struct setresgid_args *uap
+parms: td, uap
+errors:
+  - EPERM
+  - EFAULT

--- a/src/module/codegen/freebsd/setresuid.yml
+++ b/src/module/codegen/freebsd/setresuid.yml
@@ -1,0 +1,5 @@
+proto: struct thread *td, struct setresuid_args *uap
+parms: td, uap
+errors:
+  - EPERM
+  - EFAULT

--- a/src/module/codegen/freebsd/setreuid.yml
+++ b/src/module/codegen/freebsd/setreuid.yml
@@ -1,0 +1,4 @@
+proto: struct thread *td, struct setreuid_args *uap
+parms: td, uap
+errors:
+  - EPERM

--- a/src/module/codegen/freebsd/setsid.yml
+++ b/src/module/codegen/freebsd/setsid.yml
@@ -1,0 +1,4 @@
+proto: struct thread *td, struct setsid_args *uap
+parms: td, uap
+errors:
+  - EPERM

--- a/src/module/codegen/freebsd/setsockopt.yml
+++ b/src/module/codegen/freebsd/setsockopt.yml
@@ -1,0 +1,11 @@
+proto: struct thread *td, struct setsockopt_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - ENOTSOCK
+  - ENOPROTOOPT
+  - EFAULT
+  - EINVAL
+  - ENOMEM
+profiles:
+  - net

--- a/src/module/codegen/freebsd/settimeofday.yml
+++ b/src/module/codegen/freebsd/settimeofday.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct settimeofday_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EPERM
+profiles:
+  - time

--- a/src/module/codegen/freebsd/setuid.yml
+++ b/src/module/codegen/freebsd/setuid.yml
@@ -1,0 +1,4 @@
+proto: struct thread *td, struct setuid_args *uap
+parms: td, uap
+errors:
+  - EPERM

--- a/src/module/codegen/freebsd/shm_open.yml
+++ b/src/module/codegen/freebsd/shm_open.yml
@@ -1,0 +1,14 @@
+proto: struct thread *td, struct shm_open_args *uap
+parms: td, uap
+errors:
+  - EMFILE
+  - ENFILE
+  - EINVAL
+  - EFAULT
+  - ENAMETOOLONG
+  - EINVAL
+  - ENOENT
+  - EEXIST
+  - EACCES
+profiles:
+  - ipc

--- a/src/module/codegen/freebsd/shm_unlink.yml
+++ b/src/module/codegen/freebsd/shm_unlink.yml
@@ -1,0 +1,9 @@
+proto: struct thread *td, struct shm_unlink_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+profiles:
+  - ipc

--- a/src/module/codegen/freebsd/shmat.yml
+++ b/src/module/codegen/freebsd/shmat.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct shmat_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EMFILE
+profiles:
+  - ipc

--- a/src/module/codegen/freebsd/shmctl.yml
+++ b/src/module/codegen/freebsd/shmctl.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct shmctl_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EPERM
+  - EACCES
+profiles:
+  - ipc

--- a/src/module/codegen/freebsd/shmdt.yml
+++ b/src/module/codegen/freebsd/shmdt.yml
@@ -1,0 +1,6 @@
+proto: struct thread *td, struct shmdt_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+profiles:
+  - ipc

--- a/src/module/codegen/freebsd/shmget.yml
+++ b/src/module/codegen/freebsd/shmget.yml
@@ -1,0 +1,9 @@
+proto: struct thread *td, struct shmget_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - ENOENT
+  - ENOSPC
+  - EEXIST
+profiles:
+  - ipc

--- a/src/module/codegen/freebsd/shutdown.yml
+++ b/src/module/codegen/freebsd/shutdown.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct shutdown_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EINVAL
+  - ENOTCONN
+  - ENOTSOCK

--- a/src/module/codegen/freebsd/sigaction.yml
+++ b/src/module/codegen/freebsd/sigaction.yml
@@ -1,0 +1,4 @@
+proto: struct thread *td, struct sigaction_args *uap
+parms: td, uap
+errors:
+  - EINVAL

--- a/src/module/codegen/freebsd/sigaltstack.yml
+++ b/src/module/codegen/freebsd/sigaltstack.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct sigaltstack_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EPERM
+  - EINVAL
+  - ENOMEM

--- a/src/module/codegen/freebsd/sigpending.yml
+++ b/src/module/codegen/freebsd/sigpending.yml
@@ -1,0 +1,4 @@
+proto: struct thread *td, struct sigpending_args *uap
+parms: td, uap
+errors:
+  - EFAULT

--- a/src/module/codegen/freebsd/sigprocmask.yml
+++ b/src/module/codegen/freebsd/sigprocmask.yml
@@ -1,0 +1,4 @@
+proto: struct thread *td, struct sigprocmask_args *uap
+parms: td, uap
+errors:
+  - EINVAL

--- a/src/module/codegen/freebsd/sigqueue.yml
+++ b/src/module/codegen/freebsd/sigqueue.yml
@@ -1,0 +1,7 @@
+proto: struct thread *td, struct sigqueue_args *uap
+parms: td, uap
+errors:
+  - EAGAIN
+  - EINVAL
+  - EPERM
+  - ESRCH

--- a/src/module/codegen/freebsd/sigreturn.yml
+++ b/src/module/codegen/freebsd/sigreturn.yml
@@ -1,0 +1,5 @@
+proto: struct thread *td, struct sigreturn_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EINVAL

--- a/src/module/codegen/freebsd/sigsuspend.yml
+++ b/src/module/codegen/freebsd/sigsuspend.yml
@@ -1,0 +1,4 @@
+proto: struct thread *td, struct sigsuspend_args *uap
+parms: td, uap
+errors:
+  - EINTR

--- a/src/module/codegen/freebsd/sigtimedwait.yml
+++ b/src/module/codegen/freebsd/sigtimedwait.yml
@@ -1,0 +1,6 @@
+proto: struct thread *td, struct sigtimedwait_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EAGAIN
+  - EINTR

--- a/src/module/codegen/freebsd/sigwait.yml
+++ b/src/module/codegen/freebsd/sigwait.yml
@@ -1,0 +1,4 @@
+proto: struct thread *td, struct sigwait_args *uap
+parms: td, uap
+errors:
+  - EINVAL

--- a/src/module/codegen/freebsd/sigwaitinfo.yml
+++ b/src/module/codegen/freebsd/sigwaitinfo.yml
@@ -1,0 +1,4 @@
+proto: struct thread *td, struct sigwaitinfo_args *uap
+parms: td, uap
+errors:
+  - EINTR

--- a/src/module/codegen/freebsd/socket.yml
+++ b/src/module/codegen/freebsd/socket.yml
@@ -1,0 +1,13 @@
+proto: struct thread *td, struct socket_args *uap
+parms: td, uap
+errors:
+  - EACCES
+  - EAFNOSUPPORT
+  - EMFILE
+  - ENFILE
+  - ENOBUFS
+  - EPERM
+  - EPROTONOSUPPORT
+  - EPROTOTYPE
+profiles:
+  - net

--- a/src/module/codegen/freebsd/socketpair.yml
+++ b/src/module/codegen/freebsd/socketpair.yml
@@ -1,0 +1,10 @@
+proto: struct thread *td, struct socketpair_args *uap
+parms: td, uap
+errors:
+  - EMFILE
+  - EAFNOSUPPORT
+  - EPROTONOSUPPORT
+  - EOPNOTSUPP
+  - EFAULT
+profiles:
+  - net

--- a/src/module/codegen/freebsd/statfs.yml
+++ b/src/module/codegen/freebsd/statfs.yml
@@ -1,0 +1,12 @@
+proto: struct thread *td, struct statfs_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EFAULT
+  - EIO
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/swapoff.yml
+++ b/src/module/codegen/freebsd/swapoff.yml
@@ -1,0 +1,14 @@
+proto: struct thread *td, struct swapoff_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EPERM
+  - EFAULT
+  - EINVAL
+  - ENOMEM
+profiles:
+  - mem

--- a/src/module/codegen/freebsd/swapon.yml
+++ b/src/module/codegen/freebsd/swapon.yml
@@ -1,0 +1,16 @@
+proto: struct thread *td, struct swapon_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EPERM
+  - EFAULT
+  - ENOTBLK
+  - EBUSY
+  - ENXIO
+  - EIO
+profiles:
+  - mem

--- a/src/module/codegen/freebsd/symlink.yml
+++ b/src/module/codegen/freebsd/symlink.yml
@@ -1,0 +1,18 @@
+proto: struct thread *td, struct symlink_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EEXIST
+  - EPERM
+  - EIO
+  - EROFS
+  - ENOSPC
+  - EDQUOT
+  - EIO
+  - EFAULT
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/symlinkat.yml
+++ b/src/module/codegen/freebsd/symlinkat.yml
@@ -1,0 +1,20 @@
+proto: struct thread *td, struct symlinkat_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EEXIST
+  - EPERM
+  - EIO
+  - EROFS
+  - ENOSPC
+  - EDQUOT
+  - EIO
+  - EFAULT
+  - EBADF
+  - ENOTDIR
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/thr_new.yml
+++ b/src/module/codegen/freebsd/thr_new.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct thr_new_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - EPROCLIM
+  - EFAULT
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/truncate.yml
+++ b/src/module/codegen/freebsd/truncate.yml
@@ -1,0 +1,18 @@
+proto: struct thread *td, struct truncate_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EPERM
+  - EISDIR
+  - EROFS
+  - ETXTBSY
+  - EFBIG
+  - EINVAL
+  - EIO
+  - EFAULT
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/undelete.yml
+++ b/src/module/codegen/freebsd/undelete.yml
@@ -1,0 +1,16 @@
+proto: struct thread *td, struct undelete_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - ENAMETOOLONG
+  - EEXIST
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EPERM
+  - EINVAL
+  - EIO
+  - EROFS
+  - EFAULT
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/unlink.yml
+++ b/src/module/codegen/freebsd/unlink.yml
@@ -1,0 +1,16 @@
+proto: struct thread *td, struct unlink_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - EISDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EPERM
+  - EIO
+  - EROFS
+  - EFAULT
+  - ENOSPC
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/unlinkat.yml
+++ b/src/module/codegen/freebsd/unlinkat.yml
@@ -1,0 +1,21 @@
+proto: struct thread *td, struct unlinkat_args *uap
+parms: td, uap
+errors:
+  - ENOTDIR
+  - EISDIR
+  - ENAMETOOLONG
+  - ENOENT
+  - EACCES
+  - ELOOP
+  - EPERM
+  - EIO
+  - EROFS
+  - EFAULT
+  - ENOSPC
+  - EBADF
+  - ENOTEMPTY
+  - ENOTDIR
+  - EINVAL
+  - ENOTDIR
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/unmount.yml
+++ b/src/module/codegen/freebsd/unmount.yml
@@ -1,0 +1,12 @@
+proto: struct thread *td, struct unmount_args *uap
+parms: td, uap
+errors:
+  - EPERM
+  - ENAMETOOLONG
+  - EINVAL
+  - ENOENT
+  - EBUSY
+  - EIO
+  - EFAULT
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/utimensat.yml
+++ b/src/module/codegen/freebsd/utimensat.yml
@@ -1,0 +1,17 @@
+proto: struct thread *td, struct utimensat_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EINVAL
+  - EIO
+  - EPERM
+  - EACCES
+  - EPERM
+  - EROFS
+  - EBADF
+  - ELOOP
+  - ENAMETOOLONG
+  - ENOENT
+  - ENOTDIR
+profiles:
+  - time

--- a/src/module/codegen/freebsd/utimes.yml
+++ b/src/module/codegen/freebsd/utimes.yml
@@ -1,0 +1,15 @@
+proto: struct thread *td, struct utimes_args *uap
+parms: td, uap
+errors:
+  - EACCES
+  - EFAULT
+  - EINVAL
+  - EIO
+  - ELOOP
+  - ENAMETOOLONG
+  - ENOENT
+  - ENOTDIR
+  - EPERM
+  - EROFS
+profiles:
+  - fs

--- a/src/module/codegen/freebsd/utrace.yml
+++ b/src/module/codegen/freebsd/utrace.yml
@@ -1,0 +1,8 @@
+proto: struct thread *td, struct utrace_args *uap
+parms: td, uap
+errors:
+  - EINVAL
+  - ENOMEM
+  - ENOSYS
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/uuidgen.yml
+++ b/src/module/codegen/freebsd/uuidgen.yml
@@ -1,0 +1,5 @@
+proto: struct thread *td, struct uuidgen_args *uap
+parms: td, uap
+errors:
+  - EFAULT
+  - EINVAL

--- a/src/module/codegen/freebsd/wait4.yml
+++ b/src/module/codegen/freebsd/wait4.yml
@@ -1,0 +1,9 @@
+proto: struct thread *td, struct wait4_args *uap
+parms: td, uap
+errors:
+  - ECHILD
+  - EFAULT
+  - EINTR
+  - EINVAL
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/wait6.yml
+++ b/src/module/codegen/freebsd/wait6.yml
@@ -1,0 +1,9 @@
+proto: struct thread *td, struct wait6_args *uap
+parms: td, uap
+errors:
+  - ECHILD
+  - EFAULT
+  - EINTR
+  - EINVAL
+profiles:
+  - proc

--- a/src/module/codegen/freebsd/write.yml
+++ b/src/module/codegen/freebsd/write.yml
@@ -1,0 +1,16 @@
+proto: struct thread *td, struct write_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EPIPE
+  - EFBIG
+  - EFAULT
+  - EINVAL
+  - ENOSPC
+  - EDQUOT
+  - EIO
+  - EINTR
+  - EAGAIN
+  - EROFS
+profiles:
+  - io

--- a/src/module/codegen/freebsd/writev.yml
+++ b/src/module/codegen/freebsd/writev.yml
@@ -1,0 +1,18 @@
+proto: struct thread *td, struct writev_args *uap
+parms: td, uap
+errors:
+  - EBADF
+  - EPIPE
+  - EFBIG
+  - EFAULT
+  - EINVAL
+  - ENOSPC
+  - EDQUOT
+  - EIO
+  - EINTR
+  - EAGAIN
+  - EROFS
+  - EDESTADDRREQ
+  - ENOBUFS
+profiles:
+  - io


### PR DESCRIPTION
Big thanks to @roachspray 

Closes #26 

It really slows down the build however, and using `gmake -j2` causes issues when the BSDMake gets called.