### PR TITLE
inode targeting

### DIFF
--- a/src/krfctl/krfctl.c
+++ b/src/krfctl/krfctl.c
@@ -59,12 +59,13 @@ static void fault_syscall_profile(const char *profile) {
   }
 }
 
-enum { TARGET_PERSONALITY = 0, TARGET_PID, TARGET_UID, TARGET_GID, TARGET_NUM_MODES };
+enum { TARGET_PERSONALITY = 0, TARGET_PID, TARGET_UID, TARGET_GID, TARGET_INODE, TARGET_NUM_MODES };
 
 char *const targeting_opts[] = {[TARGET_PERSONALITY] = "personality",
                                 [TARGET_PID] = "PID",
                                 [TARGET_UID] = "UID",
                                 [TARGET_GID] = "GID",
+                                [TARGET_INODE] = "INODE",
                                 [TARGET_NUM_MODES] = NULL};
 
 int main(int argc, char *argv[]) {
@@ -130,7 +131,7 @@ int main(int argc, char *argv[]) {
              " -T <variable>=<value>       enable targeting option <variable> with value <value>\n"
              " -C                          clear the targeting options\n"
              "targeting options:\n"
-             " personality, PID, UID, and GID\n");
+             " personality, PID, UID, GID, and INODE\n");
       return 1;
     }
     }

--- a/src/module/config.h
+++ b/src/module/config.h
@@ -26,6 +26,7 @@ typedef enum {
   KRF_T_MODE_PID,
   KRF_T_MODE_UID,
   KRF_T_MODE_GID,
+  KRF_T_MODE_FILE,
   // Insert new modes here
   KRF_T_NUM_MODES
 } krf_target_mode_t;

--- a/src/module/config.h
+++ b/src/module/config.h
@@ -26,7 +26,7 @@ typedef enum {
   KRF_T_MODE_PID,
   KRF_T_MODE_UID,
   KRF_T_MODE_GID,
-  KRF_T_MODE_FILE,
+  KRF_T_MODE_INODE,
   // Insert new modes here
   KRF_T_NUM_MODES
 } krf_target_mode_t;

--- a/src/module/freebsd/Makefile.module
+++ b/src/module/freebsd/Makefile.module
@@ -1,5 +1,5 @@
 SYSCALL_C_FILES != ls syscalls/*.gen.c
-SRCS = krf.c syscalls.c ../config.c ../krf.c $(SYSCALL_C_FILES)
+SRCS = krf.c syscalls.c ../config.c ../krf.c freebsd.c $(SYSCALL_C_FILES)
 KMOD = krf
 
 # NOTE(ww): Clear the default CFLAGS flags passed in the top-level Makefile.

--- a/src/module/freebsd/Makefile.module
+++ b/src/module/freebsd/Makefile.module
@@ -1,5 +1,5 @@
 SYSCALL_C_FILES != ls syscalls/*.gen.c
-SRCS = krf.c syscalls.c ../config.c ../krf.c freebsd.c $(SYSCALL_C_FILES)
+SRCS = krf.c syscalls.c ../config.c ../krf.c freebsd.c $(SYSCALL_C_FILES) vnode_if.h
 KMOD = krf
 
 # NOTE(ww): Clear the default CFLAGS flags passed in the top-level Makefile.

--- a/src/module/freebsd/freebsd.c
+++ b/src/module/freebsd/freebsd.c
@@ -1,0 +1,53 @@
+#include "freebsd.h"
+#include "../targeting.h"
+/*#include <sys/types.h>
+#include <sys/systm.h>
+#include <sys/sysproto.h>*/
+#include <sys/proc.h>
+#include <sys/lock.h>
+#include <sys/mutex.h>
+
+bool krf_personality(unsigned int target, krf_ctx_t *context) {
+  return (context->td_proc->p_flag2 & (target));
+}
+
+#ifdef KRF_FREEBSD_UNSAFE_PID_TRAVERSAL
+bool krf_pid(unsigned int target, krf_ctx_t *context) {
+  struct proc *par = context->td_proc;
+  do {
+    if (par->p_pid == (target)) {
+      return true;
+      break;
+    }
+  } while ((par = par->p_pptr));
+  return false;
+}
+#else // Default: do a check with depth=1 using locks
+bool krf_pid(unsigned int target, krf_ctx_t *context) {
+  int ret = 0;
+  PROC_LOCK(context->td_proc);
+  if (context->td_proc->p_pid == (target)) {
+    ret = 1;
+  } else {
+    PROC_LOCK(context->td_proc->p_pptr);
+    if (context->td_proc->p_pptr->p_pid == (target))
+      ret = 1;
+    PROC_UNLOCK(context->td_proc->p_pptr);
+  }
+  PROC_UNLOCK(context->td_proc);
+  return ret;
+}
+#endif
+
+bool krf_uid(unsigned int target, krf_ctx_t *context) {
+  return (context->td_proc->p_ucred->cr_ruid ==
+          (target)); // Currently using real UID but could use effective UID (cr_uid)
+}
+
+bool krf_gid(unsigned int target, krf_ctx_t *context) {
+  return (context->td_proc->p_ucred->cr_rgid == (target));
+}
+
+bool krf_file(unsigned int target, krf_ctx_t *context) {
+  return false;
+}

--- a/src/module/freebsd/freebsd.c
+++ b/src/module/freebsd/freebsd.c
@@ -8,12 +8,12 @@
 #include <sys/file.h>
 #include <sys/filedesc.h>
 
-bool krf_personality(unsigned int target, krf_ctx_t *context) {
+__always_inline bool krf_personality(unsigned int target, krf_ctx_t *context) {
   return (context->td_proc->p_flag2 & (target));
 }
 
 #ifdef KRF_FREEBSD_UNSAFE_PID_TRAVERSAL
-bool krf_pid(unsigned int target, krf_ctx_t *context) {
+__always_inline bool krf_pid(unsigned int target, krf_ctx_t *context) {
   struct proc *par = context->td_proc;
   do {
     if (par->p_pid == (target)) {
@@ -24,7 +24,7 @@ bool krf_pid(unsigned int target, krf_ctx_t *context) {
   return false;
 }
 #else // Default: do a check with depth=1 using locks
-bool krf_pid(unsigned int target, krf_ctx_t *context) {
+__always_inline bool krf_pid(unsigned int target, krf_ctx_t *context) {
   int ret = 0;
   PROC_LOCK(context->td_proc);
   if (context->td_proc->p_pid == (target)) {
@@ -40,16 +40,16 @@ bool krf_pid(unsigned int target, krf_ctx_t *context) {
 }
 #endif
 
-bool krf_uid(unsigned int target, krf_ctx_t *context) {
+__always_inline bool krf_uid(unsigned int target, krf_ctx_t *context) {
   return (context->td_proc->p_ucred->cr_ruid ==
           (target)); // Currently using real UID but could use effective UID (cr_uid)
 }
 
-bool krf_gid(unsigned int target, krf_ctx_t *context) {
+__always_inline bool krf_gid(unsigned int target, krf_ctx_t *context) {
   return (context->td_proc->p_ucred->cr_rgid == (target));
 }
 
-bool krf_inode(unsigned int target, krf_ctx_t *context) {
+__always_inline bool krf_inode(unsigned int target, krf_ctx_t *context) {
   int i = 0;
   bool ret = false;
   struct vattr vap;

--- a/src/module/freebsd/freebsd.c
+++ b/src/module/freebsd/freebsd.c
@@ -49,7 +49,7 @@ bool krf_gid(unsigned int target, krf_ctx_t *context) {
   return (context->td_proc->p_ucred->cr_rgid == (target));
 }
 
-bool krf_file(unsigned int target, krf_ctx_t *context) {
+bool krf_inode(unsigned int target, krf_ctx_t *context) {
   int i = 0;
   bool ret = false;
   struct vattr vap;

--- a/src/module/freebsd/freebsd.h
+++ b/src/module/freebsd/freebsd.h
@@ -1,47 +1,10 @@
 #pragma once
 // FreeBSD specific definitions
-#include <sys/lock.h>
-#include <sys/mutex.h>
 #include "syscalls.h"
 
 #define KRF_SAFE_WRITE(x) x // ???
 #define KRF_LOG(...) uprintf(__VA_ARGS__)
 #define KRF_SYSCALL_TABLE sysent
-#define KRF_TARGETING_PROTO struct thread *td
 #define KRF_TARGETING_PARMS td
-#define KRF_PERSONALITY(target) (td->td_proc->p_flag2 & (target))
-#ifdef KRF_FREEBSD_UNSAFE_PID_TRAVERSAL
-#define KRF_PID(target)                                                                            \
-  ({                                                                                               \
-    struct proc *par = td->td_proc;                                                                \
-    int ret = 0;                                                                                   \
-    do {                                                                                           \
-      if (par->p_pid == (target)) {                                                                \
-        ret = 1;                                                                                   \
-        break;                                                                                     \
-      }                                                                                            \
-    } while ((par = par->p_pptr));                                                                 \
-    ret;                                                                                           \
-  })
-#else // Default: do a check with depth=1 using locks
-#define KRF_PID(target)                                                                            \
-  ({                                                                                               \
-    int ret = 0;                                                                                   \
-    PROC_LOCK(td->td_proc);                                                                        \
-    if (td->td_proc->p_pid == (target)) {                                                          \
-      ret = 1;                                                                                     \
-    } else {                                                                                       \
-      PROC_LOCK(td->td_proc->p_pptr);                                                              \
-      if (td->td_proc->p_pptr->p_pid == (target))                                                  \
-        ret = 1;                                                                                   \
-      PROC_UNLOCK(td->td_proc->p_pptr);                                                            \
-    }                                                                                              \
-    PROC_UNLOCK(td->td_proc);                                                                      \
-    ret;                                                                                           \
-  })
-#endif
-#define KRF_UID(target)                                                                            \
-  (td->td_proc->p_ucred->cr_ruid ==                                                                \
-   (target)) // Currently using real UID but could use effective UID (cr_uid)
-#define KRF_GID(target) (td->td_proc->p_ucred->cr_rgid == (target))
 #define KRF_EXTRACT_SYSCALL(x) ((x).sy_call)
+typedef struct thread krf_ctx_t;

--- a/src/module/freebsd/syscalls.h
+++ b/src/module/freebsd/syscalls.h
@@ -1,4 +1,8 @@
 #pragma once
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <sys/sysproto.h>
+#include <sys/sysent.h>
 
 #if !defined(SYS_MAXSYSCALL) || SYS_MAXSYSCALL <= 0
 #error "undefined or bizarrely defined SYS_MAXSYSCALL"

--- a/src/module/krf.c
+++ b/src/module/krf.c
@@ -29,7 +29,7 @@ void krf_flush_table(void) {
 
 int control_file_handler(unsigned int sys_num) {
   if (sys_num >= KRF_NR_SYSCALLS) {
-    KRF_LOG("krf: flushing all faulty syscalls \nn");
+    KRF_LOG("krf: flushing all faulty syscalls \n");
     krf_flush_table();
   } else if (krf_faultable_table[sys_num] != NULL) {
     KRF_SAFE_WRITE(

--- a/src/module/linux/Makefile
+++ b/src/module/linux/Makefile
@@ -9,7 +9,7 @@ KRF_SYSCALL_OBJS = $(foreach obj,$(KRF_SYSCALL_OBJS_FAKE),syscalls/$(obj))
 ccflags-y := -DKRF_CODEGEN=1 -DLINUX
 
 obj-m += $(MOD).o
-$(MOD)-objs := krf.o syscalls.o ../krf.o ../config.o $(KRF_SYSCALL_OBJS)
+$(MOD)-objs := krf.o syscalls.o linux.o ../krf.o ../config.o $(KRF_SYSCALL_OBJS)
 
 .PHONY: module
 module: all

--- a/src/module/linux/linux.c
+++ b/src/module/linux/linux.c
@@ -1,0 +1,26 @@
+#include "linux.h"
+#include <linux/fs.h>
+#include <linux/fdtable.h>
+
+__always_inline bool krf_personality(unsigned int target, krf_ctx_t *context) {
+  return (context->personality & (target));
+}
+__always_inline bool krf_pid(pid_t target, krf_ctx_t *context) {
+  return (context->pid == (target));
+}
+__always_inline bool krf_uid(unsigned int target, krf_ctx_t *context) {
+  return (context->cred->uid.val == (target));
+}
+__always_inline bool krf_gid(unsigned int target, krf_ctx_t *context) {
+  return (context->cred->gid.val == (target));
+}
+__always_inline bool krf_file(unsigned int target, krf_ctx_t *context) {
+  int i = 0;
+  while (context->files->fdt->fd[i] != NULL) {
+    if ((target == context->files->fdt->fd[i]->f_inode->i_ino)) {
+      return true;
+    }
+    i++;
+  }
+  return false;
+}

--- a/src/module/linux/linux.c
+++ b/src/module/linux/linux.c
@@ -15,7 +15,7 @@ __always_inline bool krf_uid(unsigned int target, krf_ctx_t *context) {
 __always_inline bool krf_gid(unsigned int target, krf_ctx_t *context) {
   return (context->cred->gid.val == (target));
 }
-__always_inline bool krf_file(unsigned int target, krf_ctx_t *context) {
+__always_inline bool krf_inode(unsigned int target, krf_ctx_t *context) {
   int i = 0;
   while (context->files->fdt->fd[i] != NULL) {
     if ((target == context->files->fdt->fd[i]->f_inode->i_ino)) {

--- a/src/module/linux/linux.c
+++ b/src/module/linux/linux.c
@@ -1,11 +1,12 @@
 #include "linux.h"
+#include "../targeting.h"
 #include <linux/fs.h>
 #include <linux/fdtable.h>
 
 __always_inline bool krf_personality(unsigned int target, krf_ctx_t *context) {
   return (context->personality & (target));
 }
-__always_inline bool krf_pid(pid_t target, krf_ctx_t *context) {
+__always_inline bool krf_pid(unsigned int target, krf_ctx_t *context) {
   return (context->pid == (target));
 }
 __always_inline bool krf_uid(unsigned int target, krf_ctx_t *context) {

--- a/src/module/linux/linux.h
+++ b/src/module/linux/linux.h
@@ -8,9 +8,3 @@
 #define KRF_TARGETING_PARMS current
 #define KRF_EXTRACT_SYSCALL(x) (x)
 typedef struct task_struct krf_ctx_t;
-
-bool krf_personality(unsigned int target, krf_ctx_t *context);
-bool krf_pid(pid_t target, krf_ctx_t *context);
-bool krf_uid(unsigned int target, krf_ctx_t *context);
-bool krf_gid(unsigned int target, krf_ctx_t *context);
-bool krf_file(unsigned int target, krf_ctx_t *context);

--- a/src/module/linux/linux.h
+++ b/src/module/linux/linux.h
@@ -5,10 +5,12 @@
 #define KRF_SAFE_WRITE(x) KRF_CR0_WRITE_UNLOCK(x)
 #define KRF_LOG(...) printk(KERN_INFO __VA_ARGS__)
 #define KRF_SYSCALL_TABLE sys_call_table
-#define KRF_TARGETING_PROTO void
-#define KRF_TARGETING_PARMS
-#define KRF_PERSONALITY(target) (current->personality & (target))
-#define KRF_PID(target) (current->pid == (target))
-#define KRF_UID(target) (current->cred->uid.val == (target))
-#define KRF_GID(target) (current->cred->gid.val == (target))
+#define KRF_TARGETING_PARMS current
 #define KRF_EXTRACT_SYSCALL(x) (x)
+typedef struct task_struct krf_ctx_t;
+
+bool krf_personality(unsigned int target, krf_ctx_t *context);
+bool krf_pid(pid_t target, krf_ctx_t *context);
+bool krf_uid(unsigned int target, krf_ctx_t *context);
+bool krf_gid(unsigned int target, krf_ctx_t *context);
+bool krf_file(unsigned int target, krf_ctx_t *context);

--- a/src/module/targeting.h
+++ b/src/module/targeting.h
@@ -7,7 +7,7 @@
 #include "freebsd/freebsd.h"
 #endif
 
-static __always_inline int krf_targeted(KRF_TARGETING_PROTO) {
+static __always_inline int krf_targeted(krf_ctx_t *context) {
   int targeted = 1;
   size_t i = 0;
   for (; i < KRF_T_NUM_MODES; i++) {
@@ -17,25 +17,31 @@ static __always_inline int krf_targeted(KRF_TARGETING_PROTO) {
     if (krf_target_options.mode_mask & (1 << i)) {
       switch (i) {
       case KRF_T_MODE_PERSONALITY:
-        if (KRF_PERSONALITY(krf_target_options.target_data[i]))
+        if (krf_personality(krf_target_options.target_data[i], context))
           targeted++;
         else
           targeted = 0;
         break;
       case KRF_T_MODE_PID:
-        if (KRF_PID(krf_target_options.target_data[i]))
+        if (krf_pid(krf_target_options.target_data[i], context))
           targeted++;
         else
           targeted = 0;
         break;
       case KRF_T_MODE_UID:
-        if (KRF_UID(krf_target_options.target_data[i]))
+        if (krf_uid(krf_target_options.target_data[i], context))
           targeted++;
         else
           targeted = 0;
         break;
       case KRF_T_MODE_GID:
-        if (KRF_GID(krf_target_options.target_data[i]))
+        if (krf_gid(krf_target_options.target_data[i], context))
+          targeted++;
+        else
+          targeted = 0;
+        break;
+      case KRF_T_MODE_FILE:
+        if (krf_file(krf_target_options.target_data[i], context))
           targeted++;
         else
           targeted = 0;

--- a/src/module/targeting.h
+++ b/src/module/targeting.h
@@ -7,6 +7,12 @@
 #include "freebsd/freebsd.h"
 #endif
 
+bool krf_personality(unsigned int target, krf_ctx_t *context);
+bool krf_pid(unsigned int target, krf_ctx_t *context);
+bool krf_uid(unsigned int target, krf_ctx_t *context);
+bool krf_gid(unsigned int target, krf_ctx_t *context);
+bool krf_file(unsigned int target, krf_ctx_t *context);
+
 static __always_inline int krf_targeted(krf_ctx_t *context) {
   int targeted = 1;
   size_t i = 0;

--- a/src/module/targeting.h
+++ b/src/module/targeting.h
@@ -11,7 +11,7 @@ bool krf_personality(unsigned int target, krf_ctx_t *context);
 bool krf_pid(unsigned int target, krf_ctx_t *context);
 bool krf_uid(unsigned int target, krf_ctx_t *context);
 bool krf_gid(unsigned int target, krf_ctx_t *context);
-bool krf_file(unsigned int target, krf_ctx_t *context);
+bool krf_inode(unsigned int target, krf_ctx_t *context);
 
 static __always_inline int krf_targeted(krf_ctx_t *context) {
   int targeted = 1;
@@ -46,8 +46,8 @@ static __always_inline int krf_targeted(krf_ctx_t *context) {
         else
           targeted = 0;
         break;
-      case KRF_T_MODE_FILE:
-        if (krf_file(krf_target_options.target_data[i], context))
+      case KRF_T_MODE_INODE:
+        if (krf_inode(krf_target_options.target_data[i], context))
           targeted++;
         else
           targeted = 0;


### PR DESCRIPTION
Adds targeting based on inode number, which are easily retrievable via `ls -i <file>`

Adds another targeting method as per #9.   

Also restructures targeting methods to be functions instead of macros and moves them into their own files (`linux/linux.c` and `freebsd/freebsd.c`) while moving their declarations into a shared file (`targeting.h`).