### PR TITLE
Conservative build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 dist: xenial
+env:
+  - FAULTS=conservative
+  - FAULTS=
 language: c
 compiler:
   - clang

--- a/src/module/codegen/codegen
+++ b/src/module/codegen/codegen
@@ -106,7 +106,8 @@ SYSCALLS.each do |call, spec|
     SETUP
 
     fault_table = []
-    errors = (not CONSERVATIVE and spec["unlikely_errors"]) ? (spec["errors"] + spec["unlikely_errors"]) : spec["errors"]
+    errors = spec["errors"]
+    errors += spec.fetch("unlikely_errors", []) unless CONSERVATIVE
     errors.uniq.each do |fault|
       fault_table << "krf_sys_internal_#{call}_#{fault}"
 

--- a/src/module/codegen/codegen
+++ b/src/module/codegen/codegen
@@ -8,6 +8,7 @@
 require "yaml"
 
 PLATFORM = ARGV.shift || `uname -s`.chomp!.downcase!
+CONSERVATIVE = (ARGV.shift == "conservative")
 
 abort "Barf: Unknown platform: #{PLATFORM}" unless %w[linux freebsd].include? PLATFORM
 
@@ -117,6 +118,22 @@ SYSCALLS.each do |call, spec|
           return #{FAULT_PREFIX}#{fault};
         }
       FAULT
+    end
+
+    if not CONSERVATIVE and spec["unlikely_errors"]
+      spec["unlikely_errors"].uniq.each do |fault|
+        fault_table << "krf_sys_internal_#{call}_#{fault}"
+
+        file.puts <<~FAULT
+        static #{SYSCALL_RET_TYPE} krf_sys_internal_#{call}_#{fault}(#{spec["proto"]}) {
+          if (krf_log_faults) {
+            #{PRINT}("faulting #{call} with #{fault}\\n");
+          }
+
+          return #{FAULT_PREFIX}#{fault};
+        }
+      FAULT
+      end
     end
 
     file.puts <<~TRAILER

--- a/src/module/codegen/codegen
+++ b/src/module/codegen/codegen
@@ -106,7 +106,8 @@ SYSCALLS.each do |call, spec|
     SETUP
 
     fault_table = []
-    spec["errors"].uniq.each do |fault|
+    errors = (not CONSERVATIVE and spec["unlikely_errors"]) ? (spec["errors"] + spec["unlikely_errors"]) : spec["errors"]
+    errors.uniq.each do |fault|
       fault_table << "krf_sys_internal_#{call}_#{fault}"
 
       file.puts <<~FAULT
@@ -118,22 +119,6 @@ SYSCALLS.each do |call, spec|
           return #{FAULT_PREFIX}#{fault};
         }
       FAULT
-    end
-
-    if not CONSERVATIVE and spec["unlikely_errors"]
-      spec["unlikely_errors"].uniq.each do |fault|
-        fault_table << "krf_sys_internal_#{call}_#{fault}"
-
-        file.puts <<~FAULT
-        static #{SYSCALL_RET_TYPE} krf_sys_internal_#{call}_#{fault}(#{spec["proto"]}) {
-          if (krf_log_faults) {
-            #{PRINT}("faulting #{call} with #{fault}\\n");
-          }
-
-          return #{FAULT_PREFIX}#{fault};
-        }
-      FAULT
-      end
     end
 
     file.puts <<~TRAILER

--- a/src/module/codegen/linux/accept.yml
+++ b/src/module/codegen/linux/accept.yml
@@ -1,6 +1,10 @@
 proto: int fd, struct sockaddr __user *upeer_sockaddr, int __user *upeer_addrlen
 parms: fd, upeer_sockaddr, upeer_addrlen
 errors:
+  - EBADF
+  - ECONNABORTED
+  - EFAULT
+unlikely_errors:
   - EAGAIN
   - EWOULDBLOCK
   - EBADF

--- a/src/module/codegen/linux/close.yml
+++ b/src/module/codegen/linux/close.yml
@@ -1,6 +1,8 @@
 proto: unsigned int fd
 parms: fd
 errors:
+  - EBADF
+unlikely_errors:
   # - EAGAIN
   # - EWOULDBLOCK
   - EBADF

--- a/src/module/codegen/linux/creat.yml
+++ b/src/module/codegen/linux/creat.yml
@@ -2,6 +2,11 @@ proto: const char __user *pathname, umode_t mode
 parms: pathname, mode
 errors:
   - EACCES
+  - EFAULT
+  - EEXIST
+  - EBADF
+unlikely_errors:
+  - EACCES
   - EDQUOT
   # - EEXIST
   - EFAULT

--- a/src/module/codegen/linux/open.yml
+++ b/src/module/codegen/linux/open.yml
@@ -2,6 +2,11 @@ proto: const char __user *filename, int flags, umode_t mode
 parms: filename, flags, mode
 errors:
   - EACCES
+  - EFAULT
+  - EEXIST
+  - EBADF
+unlikely_errors:
+  - EACCES
   - EDQUOT
   # - EEXIST
   - EFAULT

--- a/src/module/codegen/linux/openat.yml
+++ b/src/module/codegen/linux/openat.yml
@@ -2,6 +2,11 @@ proto: int dfd, const char __user *filename, int flags, umode_t mode
 parms: dfd, filename, flags, mode
 errors:
   - EACCES
+  - EFAULT
+  - EEXIST
+  - EBADF
+unlikely_errors:
+  - EACCES
   - EDQUOT
   # - EEXIST
   - EFAULT

--- a/src/module/codegen/linux/read.yml
+++ b/src/module/codegen/linux/read.yml
@@ -1,10 +1,11 @@
 proto: unsigned int fd, char __user *buf, size_t count
 parms: fd, buf, count
 errors:
-  # - EAGAIN
-  # - EWOULDBLOCK
   - EBADF
   - EFAULT
+unlikely_errors:
+  # - EAGAIN
+  # - EWOULDBLOCK
   - EINTR
   - EINVAL
   - EIO

--- a/src/module/codegen/linux/write.yml
+++ b/src/module/codegen/linux/write.yml
@@ -2,13 +2,14 @@ proto: unsigned int fd, const char __user *buf, size_t count
 parms: fd, buf, count
 errors:
   - EBADF
-  - EDQUOT
   - EFAULT
+  - EPERM
+unlikely_errors:
+  - EDQUOT
   - EFBIG
   - EINTR
   - EINVAL
   - ENOSPC
-  - EPERM
 profiles:
   - fs
   - io

--- a/src/module/freebsd/Makefile
+++ b/src/module/freebsd/Makefile
@@ -11,7 +11,7 @@ module: codegen
 
 .PHONY: codegen
 codegen:
-	ruby ../codegen/codegen $(PLATFORM)
+	ruby ../codegen/codegen freebsd $(FAULTS)
 
 .PHONY: insmod
 insmod:

--- a/src/module/linux/Makefile
+++ b/src/module/linux/Makefile
@@ -20,7 +20,7 @@ all: codegen
 
 .PHONY: codegen
 codegen:
-	ruby ../codegen/codegen $(PLATFORM)
+	ruby ../codegen/codegen linux $(FAULTS)
 
 clean:
 	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) clean


### PR DESCRIPTION
Builds using `make FAULTS=conservative`, and the option is passed to the codegen script.
Any other value in `FAULTS`, or no value (e.g. `make`) will cause all faults to build.

Fixes #1