### PR TITLE
Bug fixes

### DIFF
--- a/src/module/freebsd/Makefile.module
+++ b/src/module/freebsd/Makefile.module
@@ -1,5 +1,5 @@
 SYSCALL_C_FILES != ls syscalls/*.gen.c
-SRCS = krf.c syscalls.c ../config.c ../krf.c freebsd.c $(SYSCALL_C_FILES) vnode_if.h
+SRCS = krf.c syscalls.c ../config.c ../krf.c $(SYSCALL_C_FILES) vnode_if.h
 KMOD = krf
 
 # NOTE(ww): Clear the default CFLAGS flags passed in the top-level Makefile.

--- a/src/module/freebsd/targeting.h
+++ b/src/module/freebsd/targeting.h
@@ -1,3 +1,4 @@
+#pragma once
 #include "freebsd.h"
 #include "../targeting.h"
 #include <sys/proc.h>
@@ -8,12 +9,12 @@
 #include <sys/file.h>
 #include <sys/filedesc.h>
 
-__always_inline bool krf_personality(unsigned int target, krf_ctx_t *context) {
+static __always_inline bool krf_personality(unsigned int target, krf_ctx_t *context) {
   return (context->td_proc->p_flag2 & (target));
 }
 
 #ifdef KRF_FREEBSD_UNSAFE_PID_TRAVERSAL
-__always_inline bool krf_pid(unsigned int target, krf_ctx_t *context) {
+static __always_inline bool krf_pid(unsigned int target, krf_ctx_t *context) {
   struct proc *par = context->td_proc;
   do {
     if (par->p_pid == (target)) {
@@ -24,7 +25,7 @@ __always_inline bool krf_pid(unsigned int target, krf_ctx_t *context) {
   return false;
 }
 #else // Default: do a check with depth=1 using locks
-__always_inline bool krf_pid(unsigned int target, krf_ctx_t *context) {
+static __always_inline bool krf_pid(unsigned int target, krf_ctx_t *context) {
   int ret = 0;
   PROC_LOCK(context->td_proc);
   if (context->td_proc->p_pid == (target)) {
@@ -40,16 +41,16 @@ __always_inline bool krf_pid(unsigned int target, krf_ctx_t *context) {
 }
 #endif
 
-__always_inline bool krf_uid(unsigned int target, krf_ctx_t *context) {
+static __always_inline bool krf_uid(unsigned int target, krf_ctx_t *context) {
   return (context->td_proc->p_ucred->cr_ruid ==
           (target)); // Currently using real UID but could use effective UID (cr_uid)
 }
 
-__always_inline bool krf_gid(unsigned int target, krf_ctx_t *context) {
+static __always_inline bool krf_gid(unsigned int target, krf_ctx_t *context) {
   return (context->td_proc->p_ucred->cr_rgid == (target));
 }
 
-__always_inline bool krf_inode(unsigned int target, krf_ctx_t *context) {
+static __always_inline bool krf_inode(unsigned int target, krf_ctx_t *context) {
   int i = 0;
   bool ret = false;
   struct vattr vap;

--- a/src/module/linux/Makefile
+++ b/src/module/linux/Makefile
@@ -31,4 +31,5 @@ insmod: krfx.ko
 	sudo insmod $(MOD).ko
 
 rmmod:
+	sudo ../../krfctl/krfctl -c
 	sudo rmmod $(MOD)

--- a/src/module/linux/Makefile
+++ b/src/module/linux/Makefile
@@ -9,7 +9,7 @@ KRF_SYSCALL_OBJS = $(foreach obj,$(KRF_SYSCALL_OBJS_FAKE),syscalls/$(obj))
 ccflags-y := -DKRF_CODEGEN=1 -DLINUX
 
 obj-m += $(MOD).o
-$(MOD)-objs := krf.o syscalls.o linux.o ../krf.o ../config.o $(KRF_SYSCALL_OBJS)
+$(MOD)-objs := krf.o syscalls.o ../krf.o ../config.o $(KRF_SYSCALL_OBJS)
 
 .PHONY: module
 module: all

--- a/src/module/linux/targeting.h
+++ b/src/module/linux/targeting.h
@@ -1,21 +1,22 @@
+#pragma once
 #include "linux.h"
 #include "../targeting.h"
 #include <linux/fs.h>
 #include <linux/fdtable.h>
 
-__always_inline bool krf_personality(unsigned int target, krf_ctx_t *context) {
+static __always_inline bool krf_personality(unsigned int target, krf_ctx_t *context) {
   return (context->personality & (target));
 }
-__always_inline bool krf_pid(unsigned int target, krf_ctx_t *context) {
+static __always_inline bool krf_pid(unsigned int target, krf_ctx_t *context) {
   return (context->pid == (target));
 }
-__always_inline bool krf_uid(unsigned int target, krf_ctx_t *context) {
+static __always_inline bool krf_uid(unsigned int target, krf_ctx_t *context) {
   return (context->cred->uid.val == (target));
 }
-__always_inline bool krf_gid(unsigned int target, krf_ctx_t *context) {
+static __always_inline bool krf_gid(unsigned int target, krf_ctx_t *context) {
   return (context->cred->gid.val == (target));
 }
-__always_inline bool krf_inode(unsigned int target, krf_ctx_t *context) {
+static __always_inline bool krf_inode(unsigned int target, krf_ctx_t *context) {
   int i = 0;
   while (context->files->fdt->fd[i] != NULL) {
     if ((target == context->files->fdt->fd[i]->f_inode->i_ino)) {

--- a/src/module/targeting.h
+++ b/src/module/targeting.h
@@ -2,16 +2,12 @@
 #include "config.h"
 #ifdef LINUX
 #include "linux/linux.h"
+#include "linux/targeting.h"
 #endif
 #ifdef __FreeBSD__
 #include "freebsd/freebsd.h"
+#include "freebsd/targeting.h"
 #endif
-
-bool krf_personality(unsigned int target, krf_ctx_t *context);
-bool krf_pid(unsigned int target, krf_ctx_t *context);
-bool krf_uid(unsigned int target, krf_ctx_t *context);
-bool krf_gid(unsigned int target, krf_ctx_t *context);
-bool krf_inode(unsigned int target, krf_ctx_t *context);
 
 static __always_inline int krf_targeted(krf_ctx_t *context) {
   int targeted = 1;


### PR DESCRIPTION
Enforces the `always_inline` for targeting functions, which was previously not done due to the definitions not being available, ~~and fixes the kernel oops caused by `rmmod` being run before a syscall located in the module's memory finished~~.