### PR TITLE
Netlink support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ modules.order
 *~
 src/krfexec/krfexec
 src/krfctl/krfctl
+src/krfmesg/krfmesg
 src/module/codegen/.*.mk
 *.bak
 example/*

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export PLATFORM := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ALL_SRCS := $(shell find . -type f \( -name '*.c' -o -name '*.h' \))
 PREFIX = /usr/local
 
-all: module krfexec krfctl example
+all: module krfexec krfctl krfmesg example
 
 .PHONY: module
 module:
@@ -16,6 +16,10 @@ krfexec:
 .PHONY: krfctl
 krfctl:
 	$(MAKE) -C src/krfctl
+
+.PHONY: krfmesg
+krfmesg:
+	$(MAKE) -C src/krfmesg
 
 .PHONY: insmod
 insmod:

--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,11 @@ install-module: module
 	$(MAKE) -C src/module/$(PLATFORM) install
 
 .PHONY: install-utils
-install-utils: krfexec krfctl
+install-utils: krfexec krfctl krfmesg
 	install -d $(DESTDIR)$(PREFIX)/bin
 	install src/krfexec/krfexec $(DESTDIR)$(PREFIX)/bin
 	install src/krfctl/krfctl $(DESTDIR)$(PREFIX)/bin
+	install src/krfmesg/krfmesg $(DESTDIR)$(PREFIX)/bin
 
 .PHONY: install
 install: install-module install-utils

--- a/src/krfmesg/Makefile
+++ b/src/krfmesg/Makefile
@@ -1,0 +1,11 @@
+PROG := krfmesg
+SRCS := $(PROG).c $(wildcard $(PLATFORM)/*.c)
+OBJS := $(SRCS:.c=.o)
+
+all: $(PROG)
+
+$(PROG): $(OBJS)
+
+.PHONY: clean
+clean:
+	rm -f $(PROG) $(OBJS)

--- a/src/krfmesg/freebsd/krfmesg.c
+++ b/src/krfmesg/freebsd/krfmesg.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
+#include <err.h>
 
-int platformMain(int argc, char *argv[]) {
-  printf("krfmesg not implemented on FreeBSD, since no netlink sockets\n");
+int platform_main(int argc, char *argv[]) {
+  errx(1, "krfmesg not implemented on FreeBSD, since no netlink sockets");
   return 0;
 }

--- a/src/krfmesg/freebsd/krfmesg.c
+++ b/src/krfmesg/freebsd/krfmesg.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int platformMain(int argc, char *argv[]) {
+  printf("krfmesg not implemented on FreeBSD, since no netlink sockets\n");
+  return 0;
+}

--- a/src/krfmesg/krfmesg.c
+++ b/src/krfmesg/krfmesg.c
@@ -1,5 +1,5 @@
-int platformMain(int, char **);
+int platform_main(int, char **);
 
 int main(int argc, char *argv[]) {
-  return platformMain(argc, argv);
+  return platform_main(argc, argv);
 }

--- a/src/krfmesg/krfmesg.c
+++ b/src/krfmesg/krfmesg.c
@@ -1,0 +1,5 @@
+int platformMain(int, char **);
+
+int main(int argc, char *argv[]) {
+  return platformMain(argc, argv);
+}

--- a/src/krfmesg/linux/krfmesg.c
+++ b/src/krfmesg/linux/krfmesg.c
@@ -6,18 +6,18 @@
 #include <unistd.h>
 
 /* Protocol family, consistent in both kernel prog and user prog. */
-#define MYPROTO 28 // NETLINK_USERSOCK
+#define NETLINK_KRF 28
 /* Multicast group, consistent in both kernel prog and user prog. */
-#define MYMGRP 28
+#define KRF_MGRP 28
 
 int open_netlink(void) {
   int sock;
   struct sockaddr_nl addr;
-  int group = MYMGRP;
+  int group = KRF_MGRP;
 
-  sock = socket(AF_NETLINK, SOCK_RAW, MYPROTO);
+  sock = socket(AF_NETLINK, SOCK_RAW, NETLINK_KRF);
   if (sock < 0) {
-    printf("sock < 0.\n");
+    printf("Failed to make socket. Is krf module installed?\n");
     return sock;
   }
 
@@ -25,10 +25,10 @@ int open_netlink(void) {
   addr.nl_family = AF_NETLINK;
   addr.nl_pid = getpid();
   /* This doesn't work for some reason. See the setsockopt() below. */
-  /* addr.nl_groups = MYMGRP; */
+  /* addr.nl_groups = KRF_MGRP; */
 
   if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
-    printf("bind < 0.\n");
+    printf("Failed to bind socket\n");
     return -1;
   }
 
@@ -39,7 +39,7 @@ int open_netlink(void) {
    * http://stackoverflow.com/questions/17732044/
    */
   if (setsockopt(sock, 270, NETLINK_ADD_MEMBERSHIP, &group, sizeof(group)) < 0) {
-    printf("setsockopt < 0\n");
+    printf("Failed to setsockopt. Is krfmesg being run with sudo?\n");
     // Will need to be run with sudo
     return -1;
   }

--- a/src/krfmesg/linux/krfmesg.c
+++ b/src/krfmesg/linux/krfmesg.c
@@ -12,7 +12,7 @@
 /* Multicast group, consistent in both kernel prog and user prog. */
 #define KRF_MGRP 28
 
-static sig_atomic_t exiting = 0;
+static sig_atomic_t exiting;
 
 int open_netlink(void) {
   int sock;
@@ -75,16 +75,11 @@ static void exit_sig(int signo) {
 }
 
 int platform_main(int argc, char *argv[]) {
-  int nls;
-
   sigaction(SIGINT, &(struct sigaction){.sa_handler = exit_sig}, NULL);
   sigaction(SIGTERM, &(struct sigaction){.sa_handler = exit_sig}, NULL);
   sigaction(SIGABRT, &(struct sigaction){.sa_handler = exit_sig}, NULL);
 
-  nls = open_netlink();
-  if (nls < 0) {
-    return nls;
-  }
+  int nls = open_netlink();
 
   while (!exiting) {
     read_event(nls);

--- a/src/krfmesg/linux/krfmesg.c
+++ b/src/krfmesg/linux/krfmesg.c
@@ -1,0 +1,82 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <linux/netlink.h>
+#include <unistd.h>
+
+/* Protocol family, consistent in both kernel prog and user prog. */
+#define MYPROTO 28 // NETLINK_USERSOCK
+/* Multicast group, consistent in both kernel prog and user prog. */
+#define MYMGRP 28
+
+int open_netlink(void) {
+  int sock;
+  struct sockaddr_nl addr;
+  int group = MYMGRP;
+
+  sock = socket(AF_NETLINK, SOCK_RAW, MYPROTO);
+  if (sock < 0) {
+    printf("sock < 0.\n");
+    return sock;
+  }
+
+  memset((void *)&addr, 0, sizeof(addr));
+  addr.nl_family = AF_NETLINK;
+  addr.nl_pid = getpid();
+  /* This doesn't work for some reason. See the setsockopt() below. */
+  /* addr.nl_groups = MYMGRP; */
+
+  if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    printf("bind < 0.\n");
+    return -1;
+  }
+
+  /*
+   * 270 is SOL_NETLINK. See
+   * http://lxr.free-electrons.com/source/include/linux/socket.h?v=4.1#L314
+   * and
+   * http://stackoverflow.com/questions/17732044/
+   */
+  if (setsockopt(sock, 270, NETLINK_ADD_MEMBERSHIP, &group, sizeof(group)) < 0) {
+    printf("setsockopt < 0\n");
+    // Will need to be run with sudo
+    return -1;
+  }
+
+  return sock;
+}
+
+void read_event(int sock) {
+  struct sockaddr_nl nladdr;
+  struct msghdr msg;
+  struct iovec iov;
+  char buffer[65536];
+  int ret;
+
+  iov.iov_base = (void *)buffer;
+  iov.iov_len = sizeof(buffer);
+  msg.msg_name = (void *)&(nladdr);
+  msg.msg_namelen = sizeof(nladdr);
+  msg.msg_iov = &iov;
+  msg.msg_iovlen = 1;
+
+  ret = recvmsg(sock, &msg, 0);
+  if (ret < 0)
+    printf("ret < 0.\n");
+  else
+    printf("%s", (char *)NLMSG_DATA((struct nlmsghdr *)&buffer));
+}
+
+int platformMain(int argc, char *argv[]) {
+  int nls;
+
+  nls = open_netlink();
+  if (nls < 0)
+    return nls;
+
+  while (1)
+    read_event(nls);
+
+  return 0;
+}

--- a/src/krfmesg/linux/krfmesg.c
+++ b/src/krfmesg/linux/krfmesg.c
@@ -65,10 +65,9 @@ void read_event(int sock) {
 
   ret = recvmsg(sock, &msg, 0);
   if (ret < 0) {
-    err(1, "ret < 0.");
-  } else {
-    printf("%s", (char *)NLMSG_DATA((struct nlmsghdr *)&buffer));
+    err(1, "recvmsg");
   }
+  printf("%s", (char *)NLMSG_DATA((struct nlmsghdr *)&buffer));
 }
 
 static void exit_sig(int signo) {

--- a/src/module/codegen/codegen
+++ b/src/module/codegen/codegen
@@ -14,7 +14,7 @@ abort "Barf: Unknown platform: #{PLATFORM}" unless %w[linux freebsd].include? PL
 
 TYPEOF = PLATFORM == "freebsd" ? "__typeof" : "typeof"
 SYSCALL_RET_TYPE = PLATFORM == "freebsd" ? "int" : "long"
-PRINT = PLATFORM == "freebsd" ? "uprintf" : "printk"
+PRINT = PLATFORM == "freebsd" ? "uprintf" : "KRF_LOG"
 FAULT_PREFIX = PLATFORM == "freebsd" ? "" : "-"
 ASMLINKAGE = PLATFORM == "freebsd" ? "" : "asmlinkage"
 

--- a/src/module/krf.c
+++ b/src/module/krf.c
@@ -29,7 +29,7 @@ void krf_flush_table(void) {
 
 int control_file_handler(unsigned int sys_num) {
   if (sys_num >= KRF_NR_SYSCALLS) {
-    KRF_LOG("krf: flushing all faulty syscalls \n");
+    KRF_LOG("krf: flushing all faulty syscalls\n");
     krf_flush_table();
   } else if (krf_faultable_table[sys_num] != NULL) {
     KRF_SAFE_WRITE(

--- a/src/module/linux/Makefile
+++ b/src/module/linux/Makefile
@@ -10,7 +10,7 @@ KRF_SYSCALL_YMLS = $(wildcard ../codegen/linux/*.yml)
 ccflags-y := -DKRF_CODEGEN=1 -DLINUX
 
 obj-m += $(MOD).o
-$(MOD)-objs := krf.o syscalls.o ../krf.o ../config.o $(KRF_SYSCALL_OBJS)
+$(MOD)-objs := krf.o syscalls.o netlink.o ../krf.o ../config.o $(KRF_SYSCALL_OBJS)
 
 .PHONY: all
 all: module

--- a/src/module/linux/Makefile
+++ b/src/module/linux/Makefile
@@ -7,7 +7,7 @@ KRF_SYSCALL_OBJS_FAKE := $(KRF_SYSCALL_SRCS_FAKE:.c=.o)
 KRF_SYSCALL_OBJS = $(foreach obj,$(KRF_SYSCALL_OBJS_FAKE),syscalls/$(obj))
 KRF_SYSCALL_YMLS = $(wildcard ../codegen/linux/*.yml)
 
-ccflags-y := -DKRF_CODEGEN=1 -DLINUX
+ccflags-y := -DKRF_CODEGEN=1 -DLINUX -std=gnu99 -Wno-declaration-after-statement
 
 obj-m += $(MOD).o
 $(MOD)-objs := krf.o syscalls.o netlink.o ../krf.o ../config.o $(KRF_SYSCALL_OBJS)
@@ -17,7 +17,7 @@ all: module
 
 .PHONY: module
 module: ../codegen/.linux.mk
-	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules
+	$(MAKE) V=1 -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules
 
 .PHONY: codegen
 codegen: ../codegen/.linux.mk

--- a/src/module/linux/Makefile
+++ b/src/module/linux/Makefile
@@ -17,7 +17,7 @@ all: module
 
 .PHONY: module
 module: ../codegen/.linux.mk
-	$(MAKE) V=1 -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules
+	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules
 
 .PHONY: codegen
 codegen: ../codegen/.linux.mk

--- a/src/module/linux/krf.c
+++ b/src/module/linux/krf.c
@@ -22,7 +22,7 @@ MODULE_DESCRIPTION("A Kernelspace Randomized Faulter");
 
 struct sock *krf_socket;
 
-int netlinkOut(char *buf, size_t message_size) {
+int krf_netlink_broadcast(char *buf, size_t message_size) {
   struct sk_buff *skb;
   struct nlmsghdr *nlh;
   int result;

--- a/src/module/linux/krf.c
+++ b/src/module/linux/krf.c
@@ -84,8 +84,9 @@ void cleanup_module(void) {
 }
 
 static int krf_init(void) {
-  if (setup_netlink_socket() < 0)
+  if (setup_netlink_socket() < 0) {
     return -1;
+  }
 
   sys_call_table = (void *)kallsyms_lookup_name("sys_call_table");
 

--- a/src/module/linux/krf.c
+++ b/src/module/linux/krf.c
@@ -4,16 +4,41 @@
 #include <linux/unistd.h>
 #include <linux/proc_fs.h>
 #include <linux/string.h>
+#include <linux/netlink.h>
+#include <net/netlink.h>
+#include <net/net_namespace.h>
 
 #include "../config.h"
 #include "../krf.h"
 #include "syscalls.h"
 
 #define KRF_VERSION "0.0.1"
+#define NETLINK_KRF 28
+#define NETLINK_MYGROUP 28
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("William Woodruff <william@yossarian.net>");
 MODULE_DESCRIPTION("A Kernelspace Randomized Faulter");
+
+struct sock *krf_socket;
+
+int netlinkOut(char *buf, size_t message_size) {
+  struct sk_buff *skb;
+  struct nlmsghdr *nlh;
+  int result;
+  skb = nlmsg_new(NLMSG_ALIGN(message_size), GFP_KERNEL);
+  if (!skb) {
+    printk(KERN_ERR "Failed to allocate a new skb\n");
+    return -1;
+  }
+  nlh = nlmsg_put(skb, 0, 1, NLMSG_DONE, message_size, 0);
+  strncpy(nlmsg_data(nlh), buf, message_size);
+  result = nlmsg_multicast(krf_socket, skb, 0, NETLINK_MYGROUP, GFP_KERNEL);
+  if (result < 0) {
+    printk(KERN_ERR "Failed to multicast message with error code %d\n", result);
+  }
+  return result;
+}
 
 static int krf_init(void);
 // static void krf_flush_table(void);
@@ -83,11 +108,20 @@ void cleanup_module(void) {
 }
 
 static int krf_init(void) {
+  struct netlink_kernel_cfg config = {
+      .groups = NETLINK_MYGROUP,
+  };
+  krf_socket = netlink_kernel_create(&init_net, NETLINK_KRF, &config);
+  if (krf_socket < 0) {
+    printk(KERN_ERR "krf couldn't create a netlink");
+    return -1;
+  }
+
   sys_call_table = (void *)kallsyms_lookup_name("sys_call_table");
 
   if (sys_call_table == NULL) {
     printk(KERN_ERR "krf couldn't load the syscall table\n");
-    return -1;
+    return -2;
   }
 
   memcpy(krf_sys_call_table, sys_call_table, KRF_NR_SYSCALLS * sizeof(unsigned long *));
@@ -125,6 +159,7 @@ static int krf_init(void) {
 static void krf_teardown(void) {
   krf_flush_table();
   remove_proc_subtree(KRF_PROC_DIR, NULL);
+  netlink_kernel_release(krf_socket);
 }
 
 static ssize_t rng_state_file_read(struct file *f, char __user *ubuf, size_t size, loff_t *off) {

--- a/src/module/linux/linux.h
+++ b/src/module/linux/linux.h
@@ -2,8 +2,20 @@
 // Linux specific definitions
 #include "syscalls.h"
 
+int netlinkOut(char *buf, size_t buflen);
+#define KRF_NETLINK_BUF_SIZE 48
+#define linkOut(...)                                                                               \
+  ({                                                                                               \
+    char buf[KRF_NETLINK_BUF_SIZE]; /* max message size */                                         \
+    snprintf(buf, KRF_NETLINK_BUF_SIZE, __VA_ARGS__);                                              \
+    netlinkOut(buf, strlen(buf) + 1);                                                              \
+  })
+
 #define KRF_SAFE_WRITE(x) KRF_CR0_WRITE_UNLOCK(x)
-#define KRF_LOG(...) printk(KERN_INFO __VA_ARGS__)
+#define KRF_LOG(...) ({							\
+  printk(KERN_INFO __VA_ARGS__);                                                                   \
+  linkOut(__VA_ARGS__);
+})
 #define KRF_SYSCALL_TABLE sys_call_table
 #define KRF_TARGETING_PARMS current
 #define KRF_EXTRACT_SYSCALL(x) (x)

--- a/src/module/linux/linux.h
+++ b/src/module/linux/linux.h
@@ -6,21 +6,17 @@
 #define KRF_SAFE_WRITE(x) KRF_CR0_WRITE_UNLOCK(x)
 #define KRF_LOG(...)                                                                               \
   ({                                                                                               \
-    int krf_snprintf_ret_val;                                                                      \
-    get_cpu_var(krf_log_msg_buf);                                                                  \
+    char krf_log_msg_buf[KRF_NETLINK_BUF_SIZE];                                                    \
     printk(KERN_INFO __VA_ARGS__);                                                                 \
-    krf_snprintf_ret_val = snprintf(krf_log_msg_buf, KRF_NETLINK_BUF_SIZE, __VA_ARGS__);           \
-    if (krf_snprintf_ret_val < 0) {                                                                \
+    int written = snprintf(krf_log_msg_buf, KRF_NETLINK_BUF_SIZE, __VA_ARGS__);                        \
+    if (written < 0) {                                                                             \
       printk(KERN_WARNING "snprintf formatting error");                                            \
     } else {                                                                                       \
-      krf_netlink_broadcast(krf_log_msg_buf, krf_snprintf_ret_val + 1);                            \
+      krf_netlink_broadcast(krf_log_msg_buf, written + 1);                                         \
     }                                                                                              \
-    put_cpu_var(krf_log_msg_buf);                                                                  \
   })
 #define KRF_SYSCALL_TABLE sys_call_table
 #define KRF_TARGETING_PARMS current
 #define KRF_EXTRACT_SYSCALL(x) (x)
 
 typedef struct task_struct krf_ctx_t;
-
-DECLARE_PER_CPU(char[KRF_NETLINK_BUF_SIZE], krf_log_msg_buf);

--- a/src/module/linux/linux.h
+++ b/src/module/linux/linux.h
@@ -11,6 +11,9 @@
     int written = snprintf(krf_log_msg_buf, KRF_NETLINK_BUF_SIZE, __VA_ARGS__);                    \
     if (written < 0) {                                                                             \
       printk(KERN_WARNING "snprintf formatting error");                                            \
+    } else if (written >= KRF_NETLINK_BUF_SIZE) {                                                  \
+      printk(KERN_WARNING "truncated message");                                                    \
+      krf_netlink_broadcast(krf_log_msg_buf, KRF_NETLINK_BUF_SIZE);                                \
     } else {                                                                                       \
       krf_netlink_broadcast(krf_log_msg_buf, written + 1);                                         \
     }                                                                                              \

--- a/src/module/linux/linux.h
+++ b/src/module/linux/linux.h
@@ -7,6 +7,7 @@
 #define KRF_LOG(...)                                                                               \
   ({                                                                                               \
     int krf_snprintf_ret_val;                                                                      \
+    get_cpu_var(krf_log_msg_buf);                                                                  \
     printk(KERN_INFO __VA_ARGS__);                                                                 \
     krf_snprintf_ret_val = snprintf(krf_log_msg_buf, KRF_NETLINK_BUF_SIZE, __VA_ARGS__);           \
     if (krf_snprintf_ret_val < 0) {                                                                \
@@ -14,6 +15,7 @@
     } else {                                                                                       \
       krf_netlink_broadcast(krf_log_msg_buf, krf_snprintf_ret_val + 1);                            \
     }                                                                                              \
+    put_cpu_var(krf_log_msg_buf);                                                                  \
   })
 #define KRF_SYSCALL_TABLE sys_call_table
 #define KRF_TARGETING_PARMS current

--- a/src/module/linux/linux.h
+++ b/src/module/linux/linux.h
@@ -6,10 +6,14 @@
 #define KRF_SAFE_WRITE(x) KRF_CR0_WRITE_UNLOCK(x)
 #define KRF_LOG(...)                                                                               \
   ({                                                                                               \
-    char buf[KRF_NETLINK_BUF_SIZE]; /* max message size */                                         \
+    int krf_snprintf_ret_val;                                                                      \
     printk(KERN_INFO __VA_ARGS__);                                                                 \
-    snprintf(buf, KRF_NETLINK_BUF_SIZE, __VA_ARGS__);                                              \
-    krf_netlink_broadcast(buf, strlen(buf) + 1);                                                   \
+    krf_snprintf_ret_val = snprintf(krf_log_msg_buf, KRF_NETLINK_BUF_SIZE, __VA_ARGS__);           \
+    if (krf_snprintf_ret_val < 0) {                                                                \
+      printk(KERN_WARNING "snprintf formatting error");                                            \
+    } else {                                                                                       \
+      krf_netlink_broadcast(krf_log_msg_buf, krf_snprintf_ret_val + 1);                            \
+    }                                                                                              \
   })
 #define KRF_SYSCALL_TABLE sys_call_table
 #define KRF_TARGETING_PARMS current

--- a/src/module/linux/linux.h
+++ b/src/module/linux/linux.h
@@ -1,21 +1,15 @@
 #pragma once
 // Linux specific definitions
 #include "syscalls.h"
-
-int krf_netlink_broadcast(char *buf, size_t buflen);
-#define KRF_NETLINK_BUF_SIZE 48
-#define KRF_LINK_LOG(...)                                                                          \
-  ({                                                                                               \
-    char buf[KRF_NETLINK_BUF_SIZE]; /* max message size */                                         \
-    snprintf(buf, KRF_NETLINK_BUF_SIZE, __VA_ARGS__);                                              \
-    krf_netlink_broadcast(buf, strlen(buf) + 1);                                                   \
-  })
+#include "netlink.h"
 
 #define KRF_SAFE_WRITE(x) KRF_CR0_WRITE_UNLOCK(x)
 #define KRF_LOG(...)                                                                               \
   ({                                                                                               \
+    char buf[KRF_NETLINK_BUF_SIZE]; /* max message size */                                         \
     printk(KERN_INFO __VA_ARGS__);                                                                 \
-    KRF_LINK_LOG(__VA_ARGS__);                                                                     \
+    snprintf(buf, KRF_NETLINK_BUF_SIZE, __VA_ARGS__);                                              \
+    krf_netlink_broadcast(buf, strlen(buf) + 1);                                                   \
   })
 #define KRF_SYSCALL_TABLE sys_call_table
 #define KRF_TARGETING_PARMS current

--- a/src/module/linux/linux.h
+++ b/src/module/linux/linux.h
@@ -10,9 +10,9 @@
     printk(KERN_INFO __VA_ARGS__);                                                                 \
     int written = snprintf(krf_log_msg_buf, KRF_NETLINK_BUF_SIZE, __VA_ARGS__);                    \
     if (written < 0) {                                                                             \
-      printk(KERN_WARNING "snprintf formatting error");                                            \
+      printk(KERN_WARNING "snprintf formatting error\n");                                          \
     } else if (written >= KRF_NETLINK_BUF_SIZE) {                                                  \
-      printk(KERN_WARNING "truncated message");                                                    \
+      printk(KERN_WARNING "truncated message\n");                                                  \
       krf_netlink_broadcast(krf_log_msg_buf, KRF_NETLINK_BUF_SIZE);                                \
     } else {                                                                                       \
       krf_netlink_broadcast(krf_log_msg_buf, written + 1);                                         \

--- a/src/module/linux/linux.h
+++ b/src/module/linux/linux.h
@@ -8,7 +8,7 @@
   ({                                                                                               \
     char krf_log_msg_buf[KRF_NETLINK_BUF_SIZE];                                                    \
     printk(KERN_INFO __VA_ARGS__);                                                                 \
-    int written = snprintf(krf_log_msg_buf, KRF_NETLINK_BUF_SIZE, __VA_ARGS__);                        \
+    int written = snprintf(krf_log_msg_buf, KRF_NETLINK_BUF_SIZE, __VA_ARGS__);                    \
     if (written < 0) {                                                                             \
       printk(KERN_WARNING "snprintf formatting error");                                            \
     } else {                                                                                       \

--- a/src/module/linux/linux.h
+++ b/src/module/linux/linux.h
@@ -12,10 +12,11 @@ int netlinkOut(char *buf, size_t buflen);
   })
 
 #define KRF_SAFE_WRITE(x) KRF_CR0_WRITE_UNLOCK(x)
-#define KRF_LOG(...) ({							\
-  printk(KERN_INFO __VA_ARGS__);                                                                   \
-  linkOut(__VA_ARGS__);
-})
+#define KRF_LOG(...)                                                                               \
+  ({                                                                                               \
+    printk(KERN_INFO __VA_ARGS__);                                                                 \
+    linkOut(__VA_ARGS__);                                                                          \
+  })
 #define KRF_SYSCALL_TABLE sys_call_table
 #define KRF_TARGETING_PARMS current
 #define KRF_EXTRACT_SYSCALL(x) (x)

--- a/src/module/linux/linux.h
+++ b/src/module/linux/linux.h
@@ -10,9 +10,9 @@
     printk(KERN_INFO __VA_ARGS__);                                                                 \
     int written = snprintf(krf_log_msg_buf, KRF_NETLINK_BUF_SIZE, __VA_ARGS__);                    \
     if (written < 0) {                                                                             \
-      printk(KERN_WARNING "snprintf formatting error\n");                                          \
+      printk(KERN_WARNING "krf: snprintf formatting error\n");                                     \
     } else if (written >= KRF_NETLINK_BUF_SIZE) {                                                  \
-      printk(KERN_WARNING "truncated message\n");                                                  \
+      printk(KERN_WARNING "krf: truncated message\n");                                             \
       krf_netlink_broadcast(krf_log_msg_buf, KRF_NETLINK_BUF_SIZE);                                \
     } else {                                                                                       \
       krf_netlink_broadcast(krf_log_msg_buf, written + 1);                                         \

--- a/src/module/linux/linux.h
+++ b/src/module/linux/linux.h
@@ -2,20 +2,20 @@
 // Linux specific definitions
 #include "syscalls.h"
 
-int netlinkOut(char *buf, size_t buflen);
+int krf_netlink_broadcast(char *buf, size_t buflen);
 #define KRF_NETLINK_BUF_SIZE 48
-#define linkOut(...)                                                                               \
+#define KRF_LINK_LOG(...)                                                                          \
   ({                                                                                               \
     char buf[KRF_NETLINK_BUF_SIZE]; /* max message size */                                         \
     snprintf(buf, KRF_NETLINK_BUF_SIZE, __VA_ARGS__);                                              \
-    netlinkOut(buf, strlen(buf) + 1);                                                              \
+    krf_netlink_broadcast(buf, strlen(buf) + 1);                                                   \
   })
 
 #define KRF_SAFE_WRITE(x) KRF_CR0_WRITE_UNLOCK(x)
 #define KRF_LOG(...)                                                                               \
   ({                                                                                               \
     printk(KERN_INFO __VA_ARGS__);                                                                 \
-    linkOut(__VA_ARGS__);                                                                          \
+    KRF_LINK_LOG(__VA_ARGS__);                                                                     \
   })
 #define KRF_SYSCALL_TABLE sys_call_table
 #define KRF_TARGETING_PARMS current

--- a/src/module/linux/linux.h
+++ b/src/module/linux/linux.h
@@ -20,4 +20,7 @@
 #define KRF_SYSCALL_TABLE sys_call_table
 #define KRF_TARGETING_PARMS current
 #define KRF_EXTRACT_SYSCALL(x) (x)
+
 typedef struct task_struct krf_ctx_t;
+
+DECLARE_PER_CPU(char[KRF_NETLINK_BUF_SIZE], krf_log_msg_buf);

--- a/src/module/linux/netlink.c
+++ b/src/module/linux/netlink.c
@@ -1,7 +1,8 @@
-#include "netlink.h"
 #include <linux/netlink.h>
 #include <net/netlink.h>
 #include <net/net_namespace.h>
+
+#include "netlink.h"
 
 DEFINE_PER_CPU(char[KRF_NETLINK_BUF_SIZE], krf_log_msg_buf);
 static struct sock *krf_socket;

--- a/src/module/linux/netlink.c
+++ b/src/module/linux/netlink.c
@@ -4,7 +4,6 @@
 
 #include "netlink.h"
 
-DEFINE_PER_CPU(char[KRF_NETLINK_BUF_SIZE], krf_log_msg_buf);
 static struct sock *krf_socket;
 
 int krf_netlink_broadcast(char *buf, unsigned message_size) {

--- a/src/module/linux/netlink.c
+++ b/src/module/linux/netlink.c
@@ -1,0 +1,40 @@
+#include "netlink.h"
+#include <linux/netlink.h>
+#include <net/netlink.h>
+#include <net/net_namespace.h>
+
+static struct sock *krf_socket;
+
+int krf_netlink_broadcast(char *buf, unsigned message_size) {
+  struct sk_buff *skb;
+  struct nlmsghdr *nlh;
+  int result;
+  skb = nlmsg_new(NLMSG_ALIGN(message_size), GFP_KERNEL);
+  if (!skb) {
+    printk(KERN_ERR "Failed to allocate a new skb\n");
+    return -1;
+  }
+  nlh = nlmsg_put(skb, 0, 1, NLMSG_DONE, message_size, 0);
+  strncpy(nlmsg_data(nlh), buf, message_size);
+  result = nlmsg_multicast(krf_socket, skb, 0, NETLINK_MYGROUP, GFP_KERNEL);
+  if (result < 0) {
+    printk(KERN_ERR "Failed to multicast message with error code %d\n", result);
+  }
+  return result;
+}
+
+int setup_netlink_socket(void) {
+  struct netlink_kernel_cfg config = {
+      .groups = NETLINK_MYGROUP,
+  };
+  krf_socket = netlink_kernel_create(&init_net, NETLINK_KRF, &config);
+  if (krf_socket < 0) {
+    printk(KERN_ERR "krf couldn't create a netlink");
+    return -1;
+  }
+  return 0;
+}
+
+void destroy_netlink_socket(void) {
+  netlink_kernel_release(krf_socket);
+}

--- a/src/module/linux/netlink.c
+++ b/src/module/linux/netlink.c
@@ -3,7 +3,7 @@
 #include <net/netlink.h>
 #include <net/net_namespace.h>
 
-char krf_log_msg_buf[KRF_NETLINK_BUF_SIZE];
+DEFINE_PER_CPU(char[KRF_NETLINK_BUF_SIZE], krf_log_msg_buf);
 static struct sock *krf_socket;
 
 int krf_netlink_broadcast(char *buf, unsigned message_size) {

--- a/src/module/linux/netlink.c
+++ b/src/module/linux/netlink.c
@@ -3,6 +3,7 @@
 #include <net/netlink.h>
 #include <net/net_namespace.h>
 
+char krf_log_msg_buf[KRF_NETLINK_BUF_SIZE];
 static struct sock *krf_socket;
 
 int krf_netlink_broadcast(char *buf, unsigned message_size) {

--- a/src/module/linux/netlink.c
+++ b/src/module/linux/netlink.c
@@ -12,14 +12,14 @@ int krf_netlink_broadcast(char *buf, unsigned message_size) {
   int result;
   skb = nlmsg_new(NLMSG_ALIGN(message_size), GFP_KERNEL);
   if (!skb) {
-    printk(KERN_ERR "Failed to allocate a new skb\n");
+    printk(KERN_ERR "krf: Failed to allocate a new skb\n");
     return -1;
   }
   nlh = nlmsg_put(skb, 0, 1, NLMSG_DONE, message_size, 0);
   strncpy(nlmsg_data(nlh), buf, message_size);
   result = nlmsg_multicast(krf_socket, skb, 0, NETLINK_MYGROUP, GFP_KERNEL);
   if (result < 0) {
-    printk(KERN_ERR "Failed to multicast message with error code %d\n", result);
+    printk(KERN_ERR "krf: Failed to multicast message with error code %d\n", result);
   }
   return result;
 }
@@ -30,7 +30,7 @@ int setup_netlink_socket(void) {
   };
   krf_socket = netlink_kernel_create(&init_net, NETLINK_KRF, &config);
   if (krf_socket < 0) {
-    printk(KERN_ERR "krf couldn't create a netlink");
+    printk(KERN_ERR "krf: couldn't create a netlink");
     return -1;
   }
   return 0;

--- a/src/module/linux/netlink.h
+++ b/src/module/linux/netlink.h
@@ -2,7 +2,7 @@
 
 #define NETLINK_KRF 28
 #define NETLINK_MYGROUP 28
-#define KRF_NETLINK_BUF_SIZE 1024 // Arbitrary maximum message size
+#define KRF_NETLINK_BUF_SIZE 256 // Arbitrary maximum message size
 
 int krf_netlink_broadcast(char *buf, unsigned message_size);
 int setup_netlink_socket(void);

--- a/src/module/linux/netlink.h
+++ b/src/module/linux/netlink.h
@@ -7,5 +7,3 @@
 int krf_netlink_broadcast(char *buf, unsigned message_size);
 int setup_netlink_socket(void);
 void destroy_netlink_socket(void);
-
-extern char krf_log_msg_buf[KRF_NETLINK_BUF_SIZE];

--- a/src/module/linux/netlink.h
+++ b/src/module/linux/netlink.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#define NETLINK_KRF 28
+#define NETLINK_MYGROUP 28
+#define KRF_NETLINK_BUF_SIZE 48
+
+int krf_netlink_broadcast(char *buf, unsigned message_size);
+int setup_netlink_socket(void);
+void destroy_netlink_socket(void);

--- a/src/module/linux/netlink.h
+++ b/src/module/linux/netlink.h
@@ -2,8 +2,10 @@
 
 #define NETLINK_KRF 28
 #define NETLINK_MYGROUP 28
-#define KRF_NETLINK_BUF_SIZE 48
+#define KRF_NETLINK_BUF_SIZE 1024 // Arbitrary maximum message size
 
 int krf_netlink_broadcast(char *buf, unsigned message_size);
 int setup_netlink_socket(void);
 void destroy_netlink_socket(void);
+
+extern char krf_log_msg_buf[KRF_NETLINK_BUF_SIZE];


### PR DESCRIPTION
Outputs `KRF_LOG` calls to the netlink in addition to dmesg. The netlink socket can be read by the `krfmesg` program by calling `sudo krfmesg` *after the krf module has been loaded*.

Fixes #51