### PR TITLE
Common header + krfexec personality check

### DIFF
--- a/src/common/common.h
+++ b/src/common/common.h
@@ -1,0 +1,27 @@
+#pragma once
+/* Common defines and types needed across the krf utils and module */
+
+/* Strings used to generate procfs filenames and sysctl strings */
+#define KRF_PROC_DIR "krf"
+#define KRF_RNG_STATE_FILENAME "rng_state"
+#define KRF_PROBABILITY_FILENAME "probability"
+#define KRF_CONTROL_FILENAME "control"
+#define KRF_LOG_FAULTS_FILENAME "log_faults"
+#define KRF_TARGETING_FILENAME "targeting"
+
+/* Targeting modes */
+typedef enum {
+  KRF_T_MODE_PERSONALITY = 0,
+  KRF_T_MODE_PID,
+  KRF_T_MODE_UID,
+  KRF_T_MODE_GID,
+  KRF_T_MODE_INODE,
+  // Insert new modes here
+  KRF_T_NUM_MODES
+} krf_target_mode_t;
+
+/* Netlink Defines */
+/* Protocol family, consistent in both kernel prog and user prog. */
+#define NETLINK_KRF 28
+/* Multicast group, consistent in both kernel prog and user prog. */
+#define NETLINK_MYGROUP 28

--- a/src/krfctl/freebsd/freebsd.c
+++ b/src/krfctl/freebsd/freebsd.c
@@ -12,6 +12,7 @@
 #include <sys/sysctl.h>
 
 #include "../krfctl.h"
+#include "../../common/common.h"
 
 /* control will interpret any number larger than its syscall table
  * as a command to clear all current masks.
@@ -19,11 +20,11 @@
  */
 #define CLEAR_MAGIC 65535
 
-#define CONTROL_NAME "krf.control"
-#define RNG_STATE_NAME "krf.rng_state"
-#define PROBABILITY_NAME "krf.probability"
-#define LOG_FAULTS_NAME "krf.log_faults"
-#define TARGETING_NAME "krf.targeting"
+#define CONTROL_NAME KRF_PROC_DIR "." KRF_CONTROL_FILENAME
+#define RNG_STATE_NAME KRF_PROC_DIR "." KRF_RNG_STATE_FILENAME
+#define PROBABILITY_NAME KRF_PROC_DIR "." KRF_PROBABILITY_FILENAME
+#define LOG_FAULTS_NAME KRF_PROC_DIR "." KRF_LOG_FAULTS_FILENAME
+#define TARGETING_NAME KRF_PROC_DIR "." KRF_TARGETING_FILENAME
 
 void fault_syscall(const char *sys_name) {
   const char *sys_num;

--- a/src/krfctl/krfctl.c
+++ b/src/krfctl/krfctl.c
@@ -11,6 +11,7 @@
 #include <string.h>
 
 #include "krfctl.h"
+#include "../common/common.h"
 
 const char *lookup_syscall_number(const char *sys_name) {
   for (syscall_lookup_t *elem = syscall_lookup_table; elem->sys_name != NULL; elem++) {
@@ -59,14 +60,12 @@ static void fault_syscall_profile(const char *profile) {
   }
 }
 
-enum { TARGET_PERSONALITY = 0, TARGET_PID, TARGET_UID, TARGET_GID, TARGET_INODE, TARGET_NUM_MODES };
-
-char *const targeting_opts[] = {[TARGET_PERSONALITY] = "personality",
-                                [TARGET_PID] = "PID",
-                                [TARGET_UID] = "UID",
-                                [TARGET_GID] = "GID",
-                                [TARGET_INODE] = "INODE",
-                                [TARGET_NUM_MODES] = NULL};
+char *const targeting_opts[] = {[KRF_T_MODE_PERSONALITY] = "personality",
+                                [KRF_T_MODE_PID] = "PID",
+                                [KRF_T_MODE_UID] = "UID",
+                                [KRF_T_MODE_GID] = "GID",
+                                [KRF_T_MODE_INODE] = "INODE",
+                                [KRF_T_NUM_MODES] = NULL};
 
 int main(int argc, char *argv[]) {
   char *subopts, *value;
@@ -106,7 +105,7 @@ int main(int argc, char *argv[]) {
           printf("error: there must be a value input for the targeting option\n");
           return 2;
         }
-        if (ca >= TARGET_NUM_MODES) {
+        if (ca >= KRF_T_NUM_MODES) {
           printf("error: unknown targeting option %s\n", value);
           return 3;
         }

--- a/src/krfctl/linux/linux.c
+++ b/src/krfctl/linux/linux.c
@@ -11,6 +11,7 @@
 #include <string.h>
 
 #include "../krfctl.h"
+#include "../../common/common.h"
 
 /* control will interpret any number larger than its syscall table
  * as a command to clear all current masks.
@@ -18,11 +19,11 @@
  */
 #define CLEAR_MAGIC "65535"
 
-#define CONTROL_FILE "/proc/krf/control"
-#define RNG_STATE_FILE "/proc/krf/rng_state"
-#define PROBABILITY_FILE "/proc/krf/probability"
-#define LOG_FAULTS_FILE "/proc/krf/log_faults"
-#define TARGETING_FILE "/proc/krf/targeting"
+#define CONTROL_FILE "/proc/" KRF_PROC_DIR "/" KRF_CONTROL_FILENAME
+#define RNG_STATE_FILE "/proc/" KRF_PROC_DIR "/" KRF_RNG_STATE_FILENAME
+#define PROBABILITY_FILE "/proc/" KRF_PROC_DIR "/" KRF_PROBABILITY_FILENAME
+#define LOG_FAULTS_FILE "/proc/" KRF_PROC_DIR "/" KRF_LOG_FAULTS_FILENAME
+#define TARGETING_FILE "/proc/" KRF_PROC_DIR "/" KRF_TARGETING_FILENAME
 
 void fault_syscall(const char *sys_name) {
   int fd;

--- a/src/krfexec/freebsd/freebsd.c
+++ b/src/krfexec/freebsd/freebsd.c
@@ -9,6 +9,7 @@
 #include <pwd.h>
 
 #include "../krfexec.h"
+#include "../../common/common.h"
 
 void krfexec_prep(void) {
   char buf[32] = {0};
@@ -17,7 +18,8 @@ void krfexec_prep(void) {
     errx(1, "snprintf");
   }
 
-  if (sysctlbyname(KRF_TARGETING_NAME, NULL, NULL, &buf, strnlen(buf, 32)) < 0) {
+  if (sysctlbyname(KRF_PROC_DIR "." KRF_TARGETING_FILENAME, NULL, NULL, &buf, strnlen(buf, 32)) <
+      0) {
     err(errno, "sysctl failed");
   }
 }

--- a/src/krfexec/krfexec.h
+++ b/src/krfexec/krfexec.h
@@ -6,6 +6,5 @@
 /* TODO(ww): Put this in a common include directory.
  */
 #define KRF_PERSONALITY 28
-#define KRF_TARGETING_NAME "krf.targeting"
 
 void krfexec_prep(void);

--- a/src/krfexec/linux/linux.c
+++ b/src/krfexec/linux/linux.c
@@ -1,8 +1,46 @@
 #include <sys/personality.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
 
 #include "../krfexec.h"
+#include "../../common/common.h"
+
+#define TARGETING_FILE "/proc/" KRF_PROC_DIR "/" KRF_TARGETING_FILENAME
 
 void krfexec_prep(void) {
+  // Check if personality is being targeted
+  int fd;
+  char buf[64] = {0};
+  int set = 0;
+  if ((fd = open(TARGETING_FILE, O_RDONLY)) < 0) {
+    err(errno, "open " TARGETING_FILE);
+  }
+
+  if (read(fd, buf, sizeof(buf) - 1) < 0) {
+    err(errno, "read" TARGETING_FILE);
+  }
+
+  unsigned mode, data;
+  while (sscanf(buf, "%u %u", &mode, &data) == 2) {
+    if (mode != KRF_T_MODE_PERSONALITY)
+      continue;
+
+    if (data == KRF_PERSONALITY) {
+      set = 1;
+      break;
+    } else {
+      errx(1, "Personality set to a value that krfexec does not recognize. Use `krfctl -T "
+              "personality=28` to properly set.");
+    }
+  }
+
+  if (!set) {
+    errx(1, "Personality targeting disabled. Run `krfctl -T personality=28` to enable.");
+  }
+
+  close(fd);
+
   if (personality(KRF_PERSONALITY | ADDR_NO_RANDOMIZE) < 0) {
     err(errno, "personality");
   }

--- a/src/krfmesg/linux/krfmesg.c
+++ b/src/krfmesg/linux/krfmesg.c
@@ -6,18 +6,14 @@
 #include <linux/netlink.h>
 #include <unistd.h>
 #include <signal.h>
-
-/* Protocol family, consistent in both kernel prog and user prog. */
-#define NETLINK_KRF 28
-/* Multicast group, consistent in both kernel prog and user prog. */
-#define KRF_MGRP 28
+#include "../../common/common.h"
 
 static sig_atomic_t exiting;
 
 int open_netlink(void) {
   int sock;
   struct sockaddr_nl addr;
-  int group = KRF_MGRP;
+  int group = NETLINK_MYGROUP;
 
   sock = socket(AF_NETLINK, SOCK_RAW, NETLINK_KRF);
   if (sock < 0) {
@@ -28,7 +24,7 @@ int open_netlink(void) {
   addr.nl_family = AF_NETLINK;
   addr.nl_pid = getpid();
   /* This doesn't work for some reason. See the setsockopt() below. */
-  /* addr.nl_groups = KRF_MGRP; */
+  /* addr.nl_groups = NETLINK_MYGROUP; */
 
   if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
     err(1, "Failed to bind socket");

--- a/src/module/config.h
+++ b/src/module/config.h
@@ -1,11 +1,5 @@
 #pragma once
-
-#define KRF_PROC_DIR "krf"
-#define KRF_RNG_STATE_FILENAME "rng_state"
-#define KRF_PROBABILITY_FILENAME "probability"
-#define KRF_CONTROL_FILENAME "control"
-#define KRF_LOG_FAULTS_FILENAME "log_faults"
-#define KRF_TARGETING_FILENAME "targeting"
+#include "../common/common.h"
 
 /* All of our options are unsigned ints,
  * so 32 bytes should be more than enough for their string reps
@@ -20,16 +14,6 @@ extern unsigned int krf_targeting;
 
 #define KRF_T_MODE_MAX 31
 #define KRF_T_MODE_MAX_MASK (1 << KRF_T_MODE_MAX)
-
-typedef enum {
-  KRF_T_MODE_PERSONALITY = 0,
-  KRF_T_MODE_PID,
-  KRF_T_MODE_UID,
-  KRF_T_MODE_GID,
-  KRF_T_MODE_INODE,
-  // Insert new modes here
-  KRF_T_NUM_MODES
-} krf_target_mode_t;
 
 _Static_assert(((KRF_T_NUM_MODES) <= (KRF_T_MODE_MAX)), "Too many modes");
 

--- a/src/module/freebsd/krf.c
+++ b/src/module/freebsd/krf.c
@@ -60,8 +60,8 @@ static int targeting_file_sysctl(SYSCTL_HANDLER_ARGS) {
 static int krf_init() {
   int err = 0;
   sysctl_ctx_init(&clist);
-  if (!(krf_sysctl_root =
-            SYSCTL_ADD_ROOT_NODE(&clist, OID_AUTO, "krf", CTLFLAG_RW, 0, "krf sysctl root node"))) {
+  if (!(krf_sysctl_root = SYSCTL_ADD_ROOT_NODE(&clist, OID_AUTO, KRF_PROC_DIR, CTLFLAG_RW, 0,
+                                               "krf sysctl root node"))) {
     uprintf("krf error: Failed to add root sysctl node.\n");
     return -1;
   }

--- a/src/module/linux/netlink.h
+++ b/src/module/linux/netlink.h
@@ -1,7 +1,6 @@
 #pragma once
+#include "../../common/common.h"
 
-#define NETLINK_KRF 28
-#define NETLINK_MYGROUP 28
 #define KRF_NETLINK_BUF_SIZE 256 // Arbitrary maximum message size
 
 int krf_netlink_broadcast(char *buf, unsigned message_size);


### PR DESCRIPTION
Adds common `#define`s to a common header and adds a check to `krfexec` for if personality targeting is properly enabled