### PR TITLE
Syscall support: miscellaneous #6

### DIFF
--- a/src/module/codegen/codegen
+++ b/src/module/codegen/codegen
@@ -57,7 +57,8 @@ SYSCALLS.each do |call, spec|
   # 4. syscalls/internal.gen.h, to prototype the internal wrapper
   # 5. syscalls/<syscall>.gen.c, to set up the actual faulty calls
 
-  nr = spec["nr"] || call
+  name = spec["name"] || call
+  nr = spec["nr"] || name
   number = PLATFORM == "freebsd" ? "SYS_#{nr}" : "__NR_#{nr}"
 
   hai "#{call} (nr: #{number})"
@@ -79,12 +80,12 @@ SYSCALLS.each do |call, spec|
 
   gen_files[:syscalls_x].puts <<~SYSCALLS_X
     #{SYSCALL_RET_TYPE} #{ASMLINKAGE} krf_sys_#{call}(#{spec["proto"]}) {
-      #{TYPEOF}(sys_#{call}) *real_#{call} = #{syscall_insert};
+      #{TYPEOF}(sys_#{call}) *real_#{name} = #{syscall_insert};
 
       if (krf_targeted(KRF_TARGETING_PARMS) && (KRF_RNG_NEXT() % krf_probability) == 0) {
         return krf_sys_internal_#{call}(#{spec["parms"]});
       } else {
-        return real_#{call}(#{spec["parms"]});
+        return real_#{name}(#{spec["parms"]});
       }
     }
   SYSCALLS_X

--- a/src/module/codegen/linux/adjtimex.yml
+++ b/src/module/codegen/linux/adjtimex.yml
@@ -1,0 +1,8 @@
+proto: struct timex __user *txc_p
+parms: txc_p
+errors:
+  - EFAULT
+  - EINVAL
+  - EPERM
+profiles:
+  - time

--- a/src/module/codegen/linux/clock_adjtime.yml
+++ b/src/module/codegen/linux/clock_adjtime.yml
@@ -1,0 +1,7 @@
+proto: const clockid_t which_clock, struct timex __user *utx
+parms: which_clock, utx
+errors:
+  - EINVAL
+  - EPERM
+profiles:
+  - time

--- a/src/module/codegen/linux/ioperm.yml
+++ b/src/module/codegen/linux/ioperm.yml
@@ -1,0 +1,10 @@
+proto: unsigned long from, unsigned long num, int turn_on
+parms: from, num, turn_on
+errors:
+  - EIO
+  - EINVAL
+  - EPERM
+  - ENOMEM
+profiles:
+  - io
+  - proc

--- a/src/module/codegen/linux/pivot_root.yml
+++ b/src/module/codegen/linux/pivot_root.yml
@@ -1,0 +1,10 @@
+proto: const char __user *new_root, const char __user *put_old
+parms: new_root, put_old
+errors:
+  - EBUSY
+  - EINVAL
+  - ENOTDIR
+  - EPERM
+profiles:
+  - fs
+  - proc

--- a/src/module/codegen/linux/prctl.yml
+++ b/src/module/codegen/linux/prctl.yml
@@ -1,0 +1,16 @@
+proto: int option, unsigned long arg2, unsigned long arg3, unsigned long arg4, unsigned long arg5
+parms: option, arg2, arg3, arg4, arg5
+errors:
+  # - EACCESS
+  - EBADF
+  - EBUSY
+  - EFAULT
+  - EINVAL
+  # - EOPTNOTSUP
+  - EPERM
+profiles:
+  - fs
+  - io
+  - mm
+  - proc
+  - time

--- a/src/module/codegen/linux/readahead.yml
+++ b/src/module/codegen/linux/readahead.yml
@@ -1,0 +1,8 @@
+proto: int fd, loff_t offset, size_t count
+parms: fd, offset, count
+errors:
+  - EBADF
+  - EINVAL
+profiles:
+  - fs
+  - io

--- a/src/module/codegen/linux/sysctl.yml
+++ b/src/module/codegen/linux/sysctl.yml
@@ -1,0 +1,11 @@
+name: _sysctl
+proto: struct __sysctl_args __user *args
+parms: args
+errors:
+  # - EACCESS
+  - EFAULT
+  - ENOTDIR
+  - EPERM
+profiles:
+  - fs
+  - proc

--- a/src/module/codegen/linux/vhangup.yml
+++ b/src/module/codegen/linux/vhangup.yml
@@ -1,0 +1,7 @@
+proto: void
+parms: 
+errors:
+  - EPERM
+profiles:
+  - fs
+  - proc


### PR DESCRIPTION
The change to `codegen` were necessary because, with `_sysctl` I would get:

```
/src/module/linux/syscalls.gen.h:48:19: error: ‘sys__sysctl’ undeclared here (not in a function); did you mean ‘sys_sysctl’?
 asmlinkage typeof(sys__sysctl) krf_sys__sysctl;
                   ^~~~~~~~~~~
                   sys_sysctl
```
and with `sysctl`:

```
/src/module/linux/krf.gen.x:98:21: error: ‘__NR_sysctl’ undeclared (first use in this function); did you mean ‘__NR__sysctl’?
 krf_faultable_table[__NR_sysctl] = (void *)&krf_sys_sysctl;
                     ^~~~~~~~~~~
                     __NR__sysctl
```
and similar others.