### PR TITLE
Noninteractive apt in linux vagrant provision

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,8 +10,8 @@ Vagrant.configure("2") do |config|
     linux.vm.box = "ubuntu/bionic64"
     linux.vm.provision :shell, inline: <<~PROVISION
       sudo apt update
-      sudo apt upgrade -y
-      sudo apt install -y libelf-dev build-essential ruby linux-headers-$(uname -r)
+      sudo DEBIAN_FRONTEND=noninteractive apt upgrade -y
+      sudo DEBIAN_FRONTEND=noninteractive apt install -y libelf-dev build-essential ruby linux-headers-$(uname -r)
       sudo apt autoremove apport apport-systems
       echo "/tmp/core_%e.krf.%p" | sudo tee /proc/sys/kernel/core_pattern
     PROVISION


### PR DESCRIPTION
This is to fix an issue where some upgrade/package install popups a
yes/no prompt e.g. for restarting services.