### PR TITLE
Updated krfctl to not show invalid option for '-h'

### DIFF
--- a/src/krfctl/krfctl.c
+++ b/src/krfctl/krfctl.c
@@ -70,7 +70,7 @@ char *const targeting_opts[] = {[KRF_T_MODE_PERSONALITY] = "personality",
 int main(int argc, char *argv[]) {
   char *subopts, *value;
   int c;
-  while ((c = getopt(argc, argv, "F:P:cr:p:LT:C")) != -1) {
+  while ((c = getopt(argc, argv, "F:P:cr:p:LT:Ch")) != -1) {
     switch (c) {
     case 'F': {
       fault_syscall_spec(optarg);
@@ -117,6 +117,7 @@ int main(int argc, char *argv[]) {
       set_targeting(0, "0");
       break;
     }
+    case 'h' :
     default: {
       printf("usage: krfctl <options>\n"
              "options:\n"

--- a/src/krfctl/krfctl.c
+++ b/src/krfctl/krfctl.c
@@ -117,7 +117,7 @@ int main(int argc, char *argv[]) {
       set_targeting(0, "0");
       break;
     }
-    case 'h' :
+    case 'h':
     default: {
       printf("usage: krfctl <options>\n"
              "options:\n"


### PR DESCRIPTION
PR for Issue #67: Updated /src/krfctl/krfctl.c to include appropriate message for '-h' option and not display "invalid option"

![krfctl](https://user-images.githubusercontent.com/36834943/67709256-98ebe680-f9e3-11e9-8b23-b7821a4d0548.jpg)

Closes #67.