### PR TITLE
fix conflicting types for ‘sys_call_table’

### DIFF
--- a/src/module/linux/krf.c
+++ b/src/module/linux/krf.c
@@ -138,14 +138,14 @@ static int krf_init(void) {
     return -1;
   }
 
-  sys_call_table = (void *)kallsyms_lookup_name("sys_call_table");
+  linux_sys_call_table = (void *)kallsyms_lookup_name("sys_call_table");
 
-  if (sys_call_table == NULL) {
+  if (linux_sys_call_table == NULL) {
     printk(KERN_ERR "krf couldn't load the syscall table\n");
     return -2;
   }
 
-  memcpy(krf_sys_call_table, sys_call_table, KRF_NR_SYSCALLS * sizeof(unsigned long *));
+  memcpy(krf_sys_call_table, linux_sys_call_table, KRF_NR_SYSCALLS * sizeof(unsigned long *));
 
   krf_dir = proc_mkdir(KRF_PROC_DIR, NULL);
 

--- a/src/module/linux/linux.h
+++ b/src/module/linux/linux.h
@@ -18,7 +18,7 @@
       krf_netlink_broadcast(krf_log_msg_buf, written + 1);                                         \
     }                                                                                              \
   })
-#define KRF_SYSCALL_TABLE sys_call_table
+#define KRF_SYSCALL_TABLE linux_sys_call_table
 #define KRF_TARGETING_PARMS current
 #define KRF_EXTRACT_SYSCALL(x) (x)
 

--- a/src/module/linux/syscalls.c
+++ b/src/module/linux/syscalls.c
@@ -4,7 +4,7 @@
 
 unsigned long *krf_faultable_table[KRF_NR_SYSCALLS] = {};
 unsigned long *krf_sys_call_table[KRF_NR_SYSCALLS] = {};
-unsigned long **sys_call_table = NULL;
+unsigned long **linux_sys_call_table = NULL;
 
 #ifdef KRF_CODEGEN
 #include "syscalls.gen.x"

--- a/src/module/linux/syscalls.h
+++ b/src/module/linux/syscalls.h
@@ -34,7 +34,7 @@ extern unsigned long *krf_sys_call_table[KRF_NR_SYSCALLS];
 
 /* The real syscall table, which may or may not be modified at any point.
  */
-extern unsigned long **sys_call_table;
+extern unsigned long **linux_sys_call_table;
 
 #ifdef KRF_CODEGEN
 #include "syscalls.gen.h"


### PR DESCRIPTION
Dear team of @trailofbits,

first, thanks a lot for (open sourcing) this smart and versatile project.

When trying to compile for Linux 5.10 on Debian 11 (Bullseye), I experienced the following error:

```
In file included from /root/krf/src/module/linux/krf.c:11:
/root/krf/src/module/linux/syscalls.h:37:24: error: conflicting types for ‘sys_call_table’
   37 | extern unsigned long **sys_call_table;
      |                        ^~~~~~~~~~~~~~
In file included from /usr/src/linux-headers-5.10.0-11-common/arch/x86/include/asm/elf.h:15,
                 from /usr/src/linux-headers-5.10.0-11-common/include/linux/elf.h:6,
                 from /usr/src/linux-headers-5.10.0-11-common/include/linux/module.h:18,
                 from /root/krf/src/module/linux/krf.c:1:
/usr/src/linux-headers-5.10.0-11-common/arch/x86/include/asm/syscall.h:21:29: note: previous declaration of ‘sys_call_table’ was here
   21 | extern const sys_call_ptr_t sys_call_table[];
      |                             ^~~~~~~~~~~~~~
make[4]: *** [/usr/src/linux-headers-5.10.0-11-common/scripts/Makefile.build:285: /root/krf/src/module/linux/krf.o] Error 1
make[3]: *** [/usr/src/linux-headers-5.10.0-11-common/Makefile:1846: /root/krf/src/module/linux] Error 2
make[2]: *** [/usr/src/linux-headers-5.10.0-11-common/Makefile:185: __sub-make] Error 2
make[1]: *** [Makefile:20: module] Error 2
make: *** [Makefile:12: module] Error 2
```

This pull request fixed the name clash for me.

I have really close to no cred in kernel development, so please excuse an stupidity.