### PR TITLE
fix leaking file descriptor in fault_syscall if couldn't find syscall number

### DIFF
--- a/src/krfctl/linux/linux.c
+++ b/src/krfctl/linux/linux.c
@@ -45,6 +45,7 @@ int fault_syscall(const char *sys_name) {
 
   if (!(sys_num = lookup_syscall_number(sys_name))) {
     warnx("WARNING: couldn't find syscall: %s", sys_name);
+    close(fd);
     return 1;
   }
 


### PR DESCRIPTION
note this doesn't address the suggested todo to avoid opening this file over and over and in fixing this a neater solution could perhaps be found