### PR TITLE
fixed minor issue where log_faults switch function was not working

### DIFF
--- a/src/module/linux/linux.h
+++ b/src/module/linux/linux.h
@@ -12,10 +12,12 @@
     if (written < 0) {                                                                             \
       printk(KERN_WARNING "krf: snprintf formatting error\n");                                     \
     } else if (written >= KRF_NETLINK_BUF_SIZE) {                                                  \
-      printk(KERN_WARNING "krf: truncated message\n");                                             \
-      krf_netlink_broadcast(krf_log_msg_buf, KRF_NETLINK_BUF_SIZE);                                \
-    } else {                                                                                       \
-      krf_netlink_broadcast(krf_log_msg_buf, written + 1);                                         \
+      printk(KERN_WARNING "krf: truncated message\n");
+      if(krf_log_faults)                                                                           \
+        krf_netlink_broadcast(krf_log_msg_buf, KRF_NETLINK_BUF_SIZE);                              \
+    } else {
+      if(krf_log_faults)                                                                           \
+        krf_netlink_broadcast(krf_log_msg_buf, written + 1);                                       \
     }                                                                                              \
   })
 #define KRF_SYSCALL_TABLE linux_sys_call_table

--- a/src/module/linux/linux.h
+++ b/src/module/linux/linux.h
@@ -12,11 +12,11 @@
     if (written < 0) {                                                                             \
       printk(KERN_WARNING "krf: snprintf formatting error\n");                                     \
     } else if (written >= KRF_NETLINK_BUF_SIZE) {                                                  \
-      printk(KERN_WARNING "krf: truncated message\n");
-      if(krf_log_faults)                                                                           \
+      printk(KERN_WARNING "krf: truncated message\n");                                             \
+      if (krf_log_faults)                                                                          \
         krf_netlink_broadcast(krf_log_msg_buf, KRF_NETLINK_BUF_SIZE);                              \
-    } else {
-      if(krf_log_faults)                                                                           \
+    } else {                                                                                       \
+      if (krf_log_faults)                                                                          \
         krf_netlink_broadcast(krf_log_msg_buf, written + 1);                                       \
     }                                                                                              \
   })


### PR DESCRIPTION
Regardless of whether I use krfctl -L to trigger the log_faults feature on or off, krfmesg always receives log messages from the krfx kernel module, and it's back to normal after modifying the KRF_LOG macro
[demo image](https://gitee.com/nwpu_coder/note-picture/raw/master/img/20230728082954.png)
